### PR TITLE
Weapon table 2.5

### DIFF
--- a/lib/sacastats_web/templates/character/weapons.html.heex
+++ b/lib/sacastats_web/templates/character/weapons.html.heex
@@ -395,13 +395,15 @@
                         <img src={"https://census.daybreakgames.com/files/ps2/images/static/" <> (SacaStatsWeb.CharacterController.get_medal_code(SacaStatsWeb.CharacterController.get_total_values(Map.get(weapon, "weapon_kills"), @character["response"]["faction_id"]), 
                             SacaStatsWeb.CharacterController.get_total_values(Map.get(weapon, "weapon_vehicle_kills"), @character["response"]["faction_id"]))|> Integer.to_string()) <>".png"} alt="medal" class="medal float-left position-absolute top-0" width="30px"/>
                     <% end %>
-                    <img src={"https://census.daybreakgames.com" <> Map.get(weapon, "image_path", "/files/ps2/images/static/3.png")} 
-                        onerror={"this.onerror=null; this.src='" <> 
-                            (if weapon["vehicle_weapon?"], 
-                                do: Routes.static_path(@conn, "/images/character/unknownVehicleWeapon.png"), 
-                                else: Routes.static_path(@conn, "/images/character/unknownInfantryWeapon.png"))
-                            <> "'"} 
-                        alt={Map.get(weapon, "name", "N/A")} class="weapon-image mx-auto d-block"/>
+                    <div class="weapon-image-container w-100">
+                        <img src={"https://census.daybreakgames.com" <> Map.get(weapon, "image_path", "/files/ps2/images/static/3.png")} 
+                            onerror={"this.onerror=null; this.src='" <> 
+                                (if weapon["vehicle_weapon?"], 
+                                    do: Routes.static_path(@conn, "/images/character/unknownVehicleWeapon.png"), 
+                                    else: Routes.static_path(@conn, "/images/character/unknownInfantryWeapon.png"))
+                                <> "'"} 
+                            alt={Map.get(weapon, "name", "N/A")} class="weapon-image mx-auto d-block"/>
+                    </div>
                     <h5 class="weaponName align-text-bottom text-center mb-0"><%=Map.get(weapon, "name", "N/A")%></h5>
                     <div class="progress-bar-background">
                         <div id={"weapon" <> (weapon_id |> Integer.to_string()) <> "ProgressBar"} class="progress-bar progress-bar-striped progress-bar-animated aurax-progress" role="progressbar" 

--- a/lib/sacastats_web/templates/character/weapons.html.heex
+++ b/lib/sacastats_web/templates/character/weapons.html.heex
@@ -1,11 +1,11 @@
 <link rel="stylesheet" href={Routes.static_path(@conn, "/css/character/weapons.css")}/>
 
-<div class="d-none selection-mobile-menu-top selection-mobile-menu">
+<div class="selection-mobile-menu-top selection-mobile-menu">
     <div class="d-flex h-100 justify-content-between">
         <div class="w-50 align-self-center">
             <label class="menu-item h-100">
                 <div class="">
-                    <input class="form-check-input" type="checkbox" name="" id="selectall-faction-filter-option">
+                    <input class="form-check-input" type="checkbox" name="" id="selection-mobile-menu-select-all-btn">
                     <span class="pl-2">
                         Select All
                     </span>
@@ -13,29 +13,27 @@
             </label>
         </div> 
         <div class="w-50 align-self-center">
-            <label class="h-100 text-right">
-                1 Selected
-            </label>
+            <label id="selection-mobile-menu-selection-count" class="h-100 text-right pr-2"></label>
         </div> 
     </div>
 </div>
-<div class="d-none selection-mobile-menu-bottom selection-mobile-menu">
+<div class="selection-mobile-menu-bottom selection-mobile-menu">
     <div class="d-flex h-100 justify-content-center">
-        <div class="w-33 align-self-center">
+        <div id="selection-mobile-menu-copy-link-btn" class="w-33 align-self-center">
             <label class="">
                 <div class="h-100 text-center">
                     Copy Link
                 </div>
             </label>
         </div> 
-        <div class="w-33 align-self-center">
+        <div id="selection-mobile-menu-copy-text-btn" class="w-33 align-self-center">
             <label class="">
                 <div class="h-100 text-center">
                     Copy Text
                 </div>
             </label>
         </div> 
-        <div class="w-33 align-self-center">
+        <div id="selection-mobile-menu-back-btn" class="w-33 align-self-center">
             <label class="">
                 <div class="h-100 text-center">
                     Back
@@ -60,7 +58,7 @@
             <h5 class="d-block text-center text-md-left" id="table-copy-text">Copy stat text</h5>
         </div>
         <div class="col-4 text-right">
-            <p class="d-none d-md-inline context-menu-help">Ctrl-Shift-C</p>
+            <p class="d-none d-md-inline context-menu-help">Ctrl-X</p>
         </div>
     </div>
 </div>

--- a/lib/sacastats_web/templates/character/weapons.html.heex
+++ b/lib/sacastats_web/templates/character/weapons.html.heex
@@ -403,12 +403,14 @@
                             <> "'"} 
                         alt={Map.get(weapon, "name", "N/A")} class="weapon-image mx-auto d-block"/>
                     <h5 class="weaponName align-text-bottom text-center mb-0"><%=Map.get(weapon, "name", "N/A")%></h5>
-                    <div id={"weapon" <> (weapon_id |> Integer.to_string()) <> "ProgressBar"} class="progress-bar progress-bar-striped progress-bar-animated aurax-progress" role="progressbar" 
-                        aria-valuenow={"#{SacaStatsWeb.CharacterController.get_aurax_percent(SacaStatsWeb.CharacterController.get_total_values(Map.get(weapon, "weapon_kills"), @character["response"]["faction_id"]), 
-                            SacaStatsWeb.CharacterController.get_total_values(Map.get(weapon, "weapon_vehicle_kills"), @character["response"]["faction_id"]))}"} 
-                        aria-valuemin="0" aria-valuemax="100" style="width: 0;">
-                        <%= SacaStatsWeb.CharacterController.get_aurax_percent(SacaStatsWeb.CharacterController.get_total_values(Map.get(weapon, "weapon_kills"), @character["response"]["faction_id"]), 
-                            SacaStatsWeb.CharacterController.get_total_values(Map.get(weapon, "weapon_vehicle_kills"), @character["response"]["faction_id"]))%>%
+                    <div class="progress-bar-background">
+                        <div id={"weapon" <> (weapon_id |> Integer.to_string()) <> "ProgressBar"} class="progress-bar progress-bar-striped progress-bar-animated aurax-progress" role="progressbar" 
+                            aria-valuenow={"#{SacaStatsWeb.CharacterController.get_aurax_percent(SacaStatsWeb.CharacterController.get_total_values(Map.get(weapon, "weapon_kills"), @character["response"]["faction_id"]), 
+                                SacaStatsWeb.CharacterController.get_total_values(Map.get(weapon, "weapon_vehicle_kills"), @character["response"]["faction_id"]))}"} 
+                            aria-valuemin="0" aria-valuemax="100" style="width: 0;">
+                            <%= SacaStatsWeb.CharacterController.get_aurax_percent(SacaStatsWeb.CharacterController.get_total_values(Map.get(weapon, "weapon_kills"), @character["response"]["faction_id"]), 
+                                SacaStatsWeb.CharacterController.get_total_values(Map.get(weapon, "weapon_vehicle_kills"), @character["response"]["faction_id"]))%>%
+                        </div>
                     </div>
                 </td>
                 <td id={"weapon" <> (weapon_id |> Integer.to_string()) <> "Kills"} class="number text-center total-kills">

--- a/lib/sacastats_web/templates/character/weapons.html.heex
+++ b/lib/sacastats_web/templates/character/weapons.html.heex
@@ -68,7 +68,11 @@
     </div>
 </div>
 
-<div id="toolbar">
+<div class="p-0 m-0 ml-1 mt-3 float-none float-md-right search btn-group">
+        <input class="form-control search-input mx-auto" type="search" placeholder="Search Weapon Name" autocomplete="off">
+</div>
+
+<div id="weaponTable-toolbar">
 </div>
 <button id="nextAurax" class="btn btn-secondary p-0 m-0 ml-1 mt-3 float-right"  data-toggle="tooltip" data-placement="top" title="Scroll to closest weapon to auraxium">
     <img src={Routes.static_path(@conn, "/images/character/alphaAurax.png")} class="m-auto" width="30px" alt="To Next Auraxium Weapon"/>
@@ -325,21 +329,19 @@
     </div>
 </div>
 <table class="table table-bordered table-striped table-responsive-stack" id="weaponTable"
-    data-toolbar="#toolbar"
+    data-toolbar="#weaponTable-toolbar"
     data-show-columns="true"
     data-reorderable-columns="true"
     data-sort-name="kills"
     data-sort-order="desc"
     data-sticky-header="true"
     data-sticky-header-offset-y="210"
-    data-search="true"
-    data-search-on-enter-key="true"
     data-pagination="true"
     data-page-size="5"
     data-page-list="[5, 10, 25, 50, 100, 200, All]">
     <thead class="">
         <tr>
-            <th data-field="weapon" data-switchable="false" data-toggle="tooltip" title="Weapons" class="pr-5">Weapon</th>
+            <th data-field="weapon" data-switchable="false" data-toggle="tooltip" title="Weapons" class="weapon">Weapon</th>
             <th data-field="kills" data-sortable="true" data-sort-order="desc" data-toggle="tooltip" title="Total number of kills" class="drag-accept">Kills</th>
             <th data-field="vskills" data-visible="false" data-sortable="true" data-sort-order="desc" data-toggle="tooltip" title="Total number of VS kills" class="drag-accept">VS-Kills</th>
             <th data-field="nckills" data-visible="false" data-sortable="true" data-sort-order="desc" data-toggle="tooltip" title="Total number of NC kills" class="drag-accept">NC-Kills</th>
@@ -399,7 +401,7 @@
                                 do: Routes.static_path(@conn, "/images/character/unknownVehicleWeapon.png"), 
                                 else: Routes.static_path(@conn, "/images/character/unknownInfantryWeapon.png"))
                             <> "'"} 
-                        alt={Map.get(weapon, "name", "N/A")} class="weapon mx-auto d-block" height="75vh"/>
+                        alt={Map.get(weapon, "name", "N/A")} class="weapon-image mx-auto d-block"/>
                     <h5 class="weaponName align-text-bottom text-center mb-0"><%=Map.get(weapon, "name", "N/A")%></h5>
                     <div id={"weapon" <> (weapon_id |> Integer.to_string()) <> "ProgressBar"} class="progress-bar progress-bar-striped progress-bar-animated aurax-progress" role="progressbar" 
                         aria-valuenow={"#{SacaStatsWeb.CharacterController.get_aurax_percent(SacaStatsWeb.CharacterController.get_total_values(Map.get(weapon, "weapon_kills"), @character["response"]["faction_id"]), 

--- a/lib/sacastats_web/templates/character/weapons.html.heex
+++ b/lib/sacastats_web/templates/character/weapons.html.heex
@@ -1,10 +1,10 @@
 <link rel="stylesheet" href={Routes.static_path(@conn, "/css/character/weapons.css")}/>
 
 
-<div class="dropdown-menu dropdown-menu-sm pb-0" id="context-menu">
-    <h5 class="px-5 d-inline text-sm-center" id="copyWeaponLink">Copy weapon stat link<p class="d-none d-md-inline context-menu-help">Ctrl-C</p></h5>
+<div class="dropdown-menu dropdown-menu-sm pb-0" id="weaponTable-context-menu">
+    <h5 class="px-5 d-inline text-sm-center" id="weaponTable-copy-link">Copy weapon stat link<p class="d-none d-md-inline context-menu-help">Ctrl-C</p></h5>
 </div>
-<div class="dropdown-menu dropdown-menu-sm pb-0 toast" data-delay="600">
+<div id="weaponTable-copy-toast" class="dropdown-menu dropdown-menu-sm pb-0 toast" data-delay="600">
     <div class="toast-body text-center">
         <h5 class="p-3">Copied!</h5>
     </div>

--- a/lib/sacastats_web/templates/character/weapons.html.heex
+++ b/lib/sacastats_web/templates/character/weapons.html.heex
@@ -1,10 +1,26 @@
 <link rel="stylesheet" href={Routes.static_path(@conn, "/css/character/weapons.css")}/>
 
 
-<div class="dropdown-menu dropdown-menu-sm pb-0" id="weaponTable-context-menu">
-    <h5 class="px-5 d-inline text-sm-center" id="weaponTable-copy-link">Copy weapon stat link<p class="d-none d-md-inline context-menu-help">Ctrl-C</p></h5>
+<div class="dropdown-menu dropdown-menu-sm pb-0" id="table-context-menu">
+    <div class="row context-menu-row" id="table-copy-link-row">
+        <div class="col-8">
+            <h5 class="d-block text-center text-md-left" id="table-copy-link">Copy weapon stat link</h5>
+        </div>
+        <div class="col-4 text-right">
+            <p class="d-none d-md-inline context-menu-help">Ctrl-C</p>
+        </div>
+    </div>
+
+    <div class="row context-menu-row" id="table-copy-text-row">
+        <div class="col-8">
+            <h5 class="d-block text-center text-md-left" id="table-copy-text">Copy stat text</h5>
+        </div>
+        <div class="col-4 text-right">
+            <p class="d-none d-md-inline context-menu-help">Ctrl-Shift-C</p>
+        </div>
+    </div>
 </div>
-<div id="weaponTable-copy-toast" class="dropdown-menu dropdown-menu-sm pb-0 toast" data-delay="600">
+<div id="table-copy-toast" class="dropdown-menu dropdown-menu-sm pb-0 toast" data-delay="600">
     <div class="toast-body text-center">
         <h5 class="p-3">Copied!</h5>
     </div>

--- a/lib/sacastats_web/templates/character/weapons.html.heex
+++ b/lib/sacastats_web/templates/character/weapons.html.heex
@@ -1,5 +1,49 @@
 <link rel="stylesheet" href={Routes.static_path(@conn, "/css/character/weapons.css")}/>
 
+<div class="d-none selection-mobile-menu-top selection-mobile-menu">
+    <div class="d-flex h-100 justify-content-between">
+        <div class="w-50 align-self-center">
+            <label class="menu-item h-100">
+                <div class="">
+                    <input class="form-check-input" type="checkbox" name="" id="selectall-faction-filter-option">
+                    <span class="pl-2">
+                        Select All
+                    </span>
+                </div>
+            </label>
+        </div> 
+        <div class="w-50 align-self-center">
+            <label class="h-100 text-right">
+                1 Selected
+            </label>
+        </div> 
+    </div>
+</div>
+<div class="d-none selection-mobile-menu-bottom selection-mobile-menu">
+    <div class="d-flex h-100 justify-content-center">
+        <div class="w-33 align-self-center">
+            <label class="">
+                <div class="h-100 text-center">
+                    Copy Link
+                </div>
+            </label>
+        </div> 
+        <div class="w-33 align-self-center">
+            <label class="">
+                <div class="h-100 text-center">
+                    Copy Text
+                </div>
+            </label>
+        </div> 
+        <div class="w-33 align-self-center">
+            <label class="">
+                <div class="h-100 text-center">
+                    Back
+                </div>
+            </label>
+        </div> 
+    </div>
+</div>
 
 <div class="dropdown-menu dropdown-menu-sm pb-0" id="table-context-menu">
     <div class="row context-menu-row" id="table-copy-link-row">

--- a/lib/sacastats_web/templates/character/weapons.html.heex
+++ b/lib/sacastats_web/templates/character/weapons.html.heex
@@ -358,11 +358,11 @@
             <th data-field="acc" data-sortable="true" data-sort-order="desc" data-toggle="tooltip" title="Accuracy" class="drag-accept">Acc</th>
             <th data-field="hits" data-visible="false" data-sortable="true" data-sort-order="desc" data-toggle="tooltip" title="Number of hits" class="drag-accept">Hits</th>
             <th data-field="shots" data-visible="false" data-sortable="true" data-sort-order="desc" data-toggle="tooltip" title="Shots fired" class="drag-accept">Shots</th>
-            <th data-field="hs" data-sortable="true" data-sort-order="desc" data-toggle="tooltip" title="Head shots" class="drag-accept">HS</th>
-            <th data-field="vshs" data-visible="false" data-sortable="true" data-sort-order="desc" data-toggle="tooltip" title="VS head shots" class="drag-accept">VS-HS</th>
-            <th data-field="nchs" data-visible="false" data-sortable="true" data-sort-order="desc" data-toggle="tooltip" title="NC head shots" class="drag-accept">NC-HS</th>
-            <th data-field="trhs" data-visible="false" data-sortable="true" data-sort-order="desc" data-toggle="tooltip" title="TR head shots" class="drag-accept">TR-HS</th>
-            <th data-field="hsr" data-visible="false" data-sortable="true" data-sort-order="desc" data-toggle="tooltip" title="Head shots per kill" class="drag-accept">HSR</th>
+            <th data-field="hs" data-sortable="true" data-sort-order="desc" data-toggle="tooltip" title="Headshots" class="drag-accept">HS</th>
+            <th data-field="vshs" data-visible="false" data-sortable="true" data-sort-order="desc" data-toggle="tooltip" title="VS headshots" class="drag-accept">VS-HS</th>
+            <th data-field="nchs" data-visible="false" data-sortable="true" data-sort-order="desc" data-toggle="tooltip" title="NC headshots" class="drag-accept">NC-HS</th>
+            <th data-field="trhs" data-visible="false" data-sortable="true" data-sort-order="desc" data-toggle="tooltip" title="TR headshots" class="drag-accept">TR-HS</th>
+            <th data-field="hsr" data-visible="false" data-sortable="true" data-sort-order="desc" data-toggle="tooltip" title="Headshots per kill" class="drag-accept">HSR</th>
             <th data-field="damageg" data-visible="false" data-sortable="true" data-sort-order="desc" data-toggle="tooltip" title="Damage given" class="drag-accept">Damage.G</th>
             <th data-field="vsdamageg" data-visible="false" data-sortable="true" data-sort-order="desc" data-toggle="tooltip" title="VS damage given" class="drag-accept">VS-Damage.G</th>
             <th data-field="ncdamageg" data-visible="false" data-sortable="true" data-sort-order="desc" data-toggle="tooltip" title="NC damage given" class="drag-accept">NC-Damage.G</th>
@@ -413,44 +413,44 @@
                         </div>
                     </div>
                 </td>
-                <td id={"weapon" <> (weapon_id |> Integer.to_string()) <> "Kills"} class="number text-center total-kills">
+                <td data-mobile-title="Total Kills" id={"weapon" <> (weapon_id |> Integer.to_string()) <> "Kills"} class="number text-center total-kills">
                     <%=SacaStatsWeb.CharacterController.get_total_values(Map.get(weapon, "weapon_kills"), @character["response"]["faction_id"]) + SacaStatsWeb.CharacterController.get_total_values(Map.get(weapon, "weapon_vehicle_kills"), @character["response"]["faction_id"])%>
                 </td>
-                <td class="number text-center">
+                <td data-mobile-title="Total VS Kills" class="number text-center">
                     <%=SacaStats.Utils.maybe_to_int(weapon["weapon_kills"]["value_vs"]) + SacaStats.Utils.maybe_to_int(weapon["weapon_vehicle_kills"]["value_vs"])%>
                 </td>
-                <td class="number text-center">
+                <td data-mobile-title="Total NC Kills" class="number text-center">
                     <%=SacaStats.Utils.maybe_to_int(weapon["weapon_kills"]["value_nc"]) + SacaStats.Utils.maybe_to_int(weapon["weapon_vehicle_kills"]["value_nc"])%>
                 </td>
-                <td class="number text-center">
+                <td data-mobile-title="Total TR Kills" class="number text-center">
                     <%=SacaStats.Utils.maybe_to_int(weapon["weapon_kills"]["value_tr"]) + SacaStats.Utils.maybe_to_int(weapon["weapon_vehicle_kills"]["value_tr"])%>
                 </td>
-                <td class="number text-center"><%=SacaStatsWeb.CharacterController.get_total_values(Map.get(weapon, "weapon_kills"), @character["response"]["faction_id"])%></td>
-                <td class="number text-center">
+                <td data-mobile-title="Infantry Kills" class="number text-center"><%=SacaStatsWeb.CharacterController.get_total_values(Map.get(weapon, "weapon_kills"), @character["response"]["faction_id"])%></td>
+                <td data-mobile-title="VS Infantry Kills" class="number text-center">
                     <%=SacaStats.Utils.maybe_to_int(weapon["weapon_kills"]["value_vs"])%>
                 </td>
-                <td class="number text-center">
+                <td data-mobile-title="NC Infantry Kills" class="number text-center">
                     <%=SacaStats.Utils.maybe_to_int(weapon["weapon_kills"]["value_nc"])%>
                 </td>
-                <td class="number text-center">
+                <td data-mobile-title="TR Infantry Kills" class="number text-center">
                     <%=SacaStats.Utils.maybe_to_int(weapon["weapon_kills"]["value_tr"])%>
                 </td>
-                <td class="number text-center"><%=SacaStatsWeb.CharacterController.get_total_values(Map.get(weapon, "weapon_vehicle_kills"), @character["response"]["faction_id"])%></td>
-                <td class="number text-center">
+                <td data-mobile-title="Vehicle Kills" class="number text-center"><%=SacaStatsWeb.CharacterController.get_total_values(Map.get(weapon, "weapon_vehicle_kills"), @character["response"]["faction_id"])%></td>
+                <td data-mobile-title="VS Vehicle Kills" class="number text-center">
                     <%=SacaStats.Utils.maybe_to_int(weapon["weapon_vehicle_kills"]["value_vs"])%>
                 </td>
-                <td class="number text-center">
+                <td data-mobile-title="NC Vehicle Kills" class="number text-center">
                     <%=SacaStats.Utils.maybe_to_int(weapon["weapon_vehicle_kills"]["value_nc"])%>
                 </td>
-                <td class="number text-center">
+                <td data-mobile-title="TR Vehicle Kills" class="number text-center">
                     <%=SacaStats.Utils.maybe_to_int(weapon["weapon_vehicle_kills"]["value_tr"])%>
                 </td>
-                <td class="text-center">
+                <td data-mobile-title="Kill/ Death Ratio" class="text-center">
                     <%=SacaStatsWeb.CharacterController.get_percent_ratio((SacaStatsWeb.CharacterController.get_total_values(Map.get(weapon, "weapon_kills"), @character["response"]["faction_id"]) 
                     + SacaStatsWeb.CharacterController.get_total_values(Map.get(weapon, "weapon_vehicle_kills"), @character["response"]["faction_id"])),
                         SacaStats.Utils.maybe_to_int(weapon["weapon_deaths"]))%>
                 </td>
-                <td class="text-center percentage">
+                <td data-mobile-title="Accuracy" class="text-center percentage">
                     <%=SacaStatsWeb.CharacterController.get_percent_ratio(weapon["weapon_hit_count"], weapon["weapon_fire_count"])%>
                 </td>
                 <td class="number text-center">
@@ -459,59 +459,59 @@
                 <td class="number text-center">
                     <%=SacaStats.Utils.maybe_to_int(weapon["weapon_fire_count"])%>
                 </td>
-                <td class="number text-center"><%=SacaStatsWeb.CharacterController.get_total_values(Map.get(weapon, "weapon_headshots"), @character["response"]["faction_id"])%></td>
-                <td class="number text-center">
+                <td data-mobile-title="Headshots" class="number text-center"><%=SacaStatsWeb.CharacterController.get_total_values(Map.get(weapon, "weapon_headshots"), @character["response"]["faction_id"])%></td>
+                <td data-mobile-title="VS Headshots" class="number text-center">
                     <%=SacaStats.Utils.maybe_to_int(weapon["weapon_headshots"]["value_vs"])%>
                 </td>
-                <td class="number text-center">
+                <td data-mobile-title="NC Headshots" class="number text-center">
                     <%=SacaStats.Utils.maybe_to_int(weapon["weapon_headshots"]["value_nc"])%>
                 </td>
-                <td class="number text-center">
+                <td data-mobile-title="TR Headshots" class="number text-center">
                     <%=SacaStats.Utils.maybe_to_int(weapon["weapon_headshots"]["value_tr"])%>
                 </td>
-                <td class="text-center percentage">
+                <td data-mobile-title="Headshot Ratio" class="text-center percentage">
                     <%=SacaStatsWeb.CharacterController.get_percent_ratio(SacaStatsWeb.CharacterController.get_total_values(Map.get(weapon, "weapon_headshots"), @character["response"]["faction_id"]), 
                         (SacaStatsWeb.CharacterController.get_total_values(Map.get(weapon, "weapon_kills"), @character["response"]["faction_id"]) + SacaStatsWeb.CharacterController.get_total_values(Map.get(weapon, "weapon_vehicle_kills"), @character["response"]["faction_id"])))%>
                 </td>
-                <td class="number text-center"><%=SacaStatsWeb.CharacterController.get_total_values(Map.get(weapon, "weapon_damage_given"), @character["response"]["faction_id"])%></td>
-                <td class="number text-center">
+                <td data-mobile-title="Damage Given" class="number text-center"><%=SacaStatsWeb.CharacterController.get_total_values(Map.get(weapon, "weapon_damage_given"), @character["response"]["faction_id"])%></td>
+                <td data-mobile-title="VS Damage Given" class="number text-center">
                     <%=SacaStats.Utils.maybe_to_int(weapon["weapon_damage_given"]["value_vs"])%>
                 </td>
-                <td class="number text-center">
+                <td data-mobile-title="NC Damage Given" class="number text-center">
                     <%=SacaStats.Utils.maybe_to_int(weapon["weapon_damage_given"]["value_nc"])%>
                 </td>
-                <td class="number text-center">
+                <td data-mobile-title="TR Damage Given" class="number text-center">
                     <%=SacaStats.Utils.maybe_to_int(weapon["weapon_damage_given"]["value_tr"])%>
                 </td>
-                <td class="number text-center"><%=SacaStatsWeb.CharacterController.get_total_values(Map.get(weapon, "weapon_damage_taken_by"), @character["response"]["faction_id"])%></td>
-                <td class="number text-center">
+                <td data-mobile-title="Damage Taken" class="number text-center"><%=SacaStatsWeb.CharacterController.get_total_values(Map.get(weapon, "weapon_damage_taken_by"), @character["response"]["faction_id"])%></td>
+                <td data-mobile-title="VS Damage Taken" class="number text-center">
                     <%=SacaStats.Utils.maybe_to_int(weapon["weapon_damage_taken_by"]["value_vs"])%>
                 </td>
-                <td class="number text-center">
+                <td data-mobile-title="NC Damage Taken" class="number text-center">
                     <%=SacaStats.Utils.maybe_to_int(weapon["weapon_damage_taken_by"]["value_nc"])%>
                 </td>
-                <td class="number text-center">
+                <td data-mobile-title="TR Damage Taken" class="number text-center">
                     <%=SacaStats.Utils.maybe_to_int(weapon["weapon_damage_taken_by"]["value_tr"])%>
                 </td>
                 <td class="text-center seconds-to-readable"><%=SacaStats.Utils.maybe_to_int(weapon["weapon_play_time"])%></td>
                 <td class="number text-center"><%=SacaStatsWeb.CharacterController.get_cert_count(weapon["weapon_score"])%></td>
                 <td class="number text-center"><%=weapon["weapon_score"]%></td>
                 <td class="number text-center"><%=SacaStatsWeb.CharacterController.get_total_values(Map.get(weapon, "weapon_killed_by"), @character["response"]["faction_id"])%></td>
-                <td class="number text-center">
+                <td data-mobile-title="Killed By VS" class="number text-center">
                     <%=SacaStats.Utils.maybe_to_int(weapon["weapon_killed_by"]["value_vs"])%>
                 </td>
-                <td class="number text-center">
+                <td data-mobile-title="Killed By NC" class="number text-center">
                     <%=SacaStats.Utils.maybe_to_int(weapon["weapon_killed_by"]["value_nc"])%>
                 </td>
-                <td class="number text-center">
+                <td data-mobile-title="Killed By TR" class="number text-center">
                     <%=SacaStats.Utils.maybe_to_int(weapon["weapon_killed_by"]["value_tr"])%>
                 </td>
                 <td class="number text-center"><%=SacaStats.Utils.maybe_to_int(weapon["weapon_deaths"])%></td>
-                <td class="text-center"><%=if weapon["vehicle_weapon?"], do: "Yes", else: "No"%></td>
+                <td data-mobile-title="Vehicle Weapon" class="text-center"><%=if weapon["vehicle_weapon?"], do: "Yes", else: "No"%></td>
                 <td class="text-center"><%=SacaStatsWeb.CharacterController.get_faction_alias(weapon["faction_id"])%></td>
                 <td class="text-center"><%=weapon["sanction"]%></td>
                 <td class="text-center"><%=weapon["category"]%></td>
-                <td class="text-center"><%=weapon_id%></td>
+                <td data-mobile-title="Weapon ID" class="text-center"><%=weapon_id%></td>
             </tr>
         <% end %>
     </tbody>

--- a/lib/sacastats_web/templates/layout/root.html.heex
+++ b/lib/sacastats_web/templates/layout/root.html.heex
@@ -28,6 +28,10 @@
     <script type="module" src={Routes.static_path(@conn, "/js/scripts.js")}></script>
     <link rel="stylesheet" href={Routes.static_path(@conn, "/css/app.css")} />
     <link rel="stylesheet" href={Routes.static_path(@conn, "/css/styles.css")} />
+    
+    <link rel="stylesheet" href={Routes.static_path(@conn, "/css/flex-bootstrap-table.css")}/>
+    <link rel="stylesheet" href={Routes.static_path(@conn, "/css/flex-bootstrap-table-filter.css")}/>
+    <link rel="stylesheet" href={Routes.static_path(@conn, "/css/flex-bootstrap-table-selection.css")}/>
   </head>
   <body>
     <div id="loading-screen" class="d-flex justify-content-center">

--- a/priv/static/css/app.css
+++ b/priv/static/css/app.css
@@ -6,23 +6,645 @@
  * Copyright (c) 2017 CJ Patoilo Licensed under the MIT license
  */
 
-*,*:after,*:before{box-sizing:inherit}html{box-sizing:border-box;font-size:62.5%}body{color:#000000;font-family:'Helvetica', 'Arial', sans-serif;font-size:1.6em;font-weight:300;line-height:1.6}blockquote{border-left:0.3rem solid #d1d1d1;margin-left:0;margin-right:0;padding:1rem 1.5rem}blockquote *:last-child{margin-bottom:0}.button,button,input[type='button'],input[type='reset'],input[type='submit']{background-color:#0069d9;border:0.1rem solid #0069d9;border-radius:.4rem;color:#fff;cursor:pointer;display:inline-block;font-size:1.1rem;font-weight:700;height:3.8rem;letter-spacing:.1rem;line-height:3.8rem;padding:0 3.0rem;text-align:center;text-decoration:none;text-transform:uppercase;white-space:nowrap}.button:focus,.button:hover,button:focus,button:hover,input[type='button']:focus,input[type='button']:hover,input[type='reset']:focus,input[type='reset']:hover,input[type='submit']:focus,input[type='submit']:hover{background-color:#606c76;border-color:#606c76;color:#fff;outline:0}.button[disabled],button[disabled],input[type='button'][disabled],input[type='reset'][disabled],input[type='submit'][disabled]{cursor:default;opacity:.5}.button[disabled]:focus,.button[disabled]:hover,button[disabled]:focus,button[disabled]:hover,input[type='button'][disabled]:focus,input[type='button'][disabled]:hover,input[type='reset'][disabled]:focus,input[type='reset'][disabled]:hover,input[type='submit'][disabled]:focus,input[type='submit'][disabled]:hover{background-color:#0069d9;border-color:#0069d9}.button.button-outline,button.button-outline,input[type='button'].button-outline,input[type='reset'].button-outline,input[type='submit'].button-outline{background-color:transparent;color:#0069d9}.button.button-outline:focus,.button.button-outline:hover,button.button-outline:focus,button.button-outline:hover,input[type='button'].button-outline:focus,input[type='button'].button-outline:hover,input[type='reset'].button-outline:focus,input[type='reset'].button-outline:hover,input[type='submit'].button-outline:focus,input[type='submit'].button-outline:hover{background-color:transparent;border-color:#606c76;color:#606c76}.button.button-outline[disabled]:focus,.button.button-outline[disabled]:hover,button.button-outline[disabled]:focus,button.button-outline[disabled]:hover,input[type='button'].button-outline[disabled]:focus,input[type='button'].button-outline[disabled]:hover,input[type='reset'].button-outline[disabled]:focus,input[type='reset'].button-outline[disabled]:hover,input[type='submit'].button-outline[disabled]:focus,input[type='submit'].button-outline[disabled]:hover{border-color:inherit;color:#0069d9}.button.button-clear,button.button-clear,input[type='button'].button-clear,input[type='reset'].button-clear,input[type='submit'].button-clear{background-color:transparent;border-color:transparent;color:#0069d9}.button.button-clear:focus,.button.button-clear:hover,button.button-clear:focus,button.button-clear:hover,input[type='button'].button-clear:focus,input[type='button'].button-clear:hover,input[type='reset'].button-clear:focus,input[type='reset'].button-clear:hover,input[type='submit'].button-clear:focus,input[type='submit'].button-clear:hover{background-color:transparent;border-color:transparent;color:#606c76}.button.button-clear[disabled]:focus,.button.button-clear[disabled]:hover,button.button-clear[disabled]:focus,button.button-clear[disabled]:hover,input[type='button'].button-clear[disabled]:focus,input[type='button'].button-clear[disabled]:hover,input[type='reset'].button-clear[disabled]:focus,input[type='reset'].button-clear[disabled]:hover,input[type='submit'].button-clear[disabled]:focus,input[type='submit'].button-clear[disabled]:hover{color:#0069d9}code{background:#f4f5f6;border-radius:.4rem;font-size:86%;margin:0 .2rem;padding:.2rem .5rem;white-space:nowrap}pre{background:#f4f5f6;border-left:0.3rem solid #0069d9;overflow-y:hidden}pre>code{border-radius:0;display:block;padding:1rem 1.5rem;white-space:pre}hr{border:0;border-top:0.1rem solid #f4f5f6;margin:3.0rem 0}input[type='email'],input[type='number'],input[type='password'],input[type='search'],input[type='tel'],input[type='text'],input[type='url'],textarea,select{-webkit-appearance:none;-moz-appearance:none;appearance:none;background-color:transparent;border:0.1rem solid #d1d1d1;border-radius:.4rem;box-shadow:none;box-sizing:inherit;height:3.8rem;padding:.6rem 1.0rem;width:100%}input[type='email']:focus,input[type='number']:focus,input[type='password']:focus,input[type='search']:focus,input[type='tel']:focus,input[type='text']:focus,input[type='url']:focus,textarea:focus,select:focus{border-color:#0069d9;outline:0}select{background:url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" height="14" viewBox="0 0 29 14" width="29"><path fill="%23d1d1d1" d="M9.37727 3.625l5.08154 6.93523L19.54036 3.625"/></svg>') center right no-repeat;padding-right:3.0rem}select:focus{background-image:url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" height="14" viewBox="0 0 29 14" width="29"><path fill="%230069d9" d="M9.37727 3.625l5.08154 6.93523L19.54036 3.625"/></svg>')}textarea{min-height:6.5rem}label,legend{display:block;font-size:1.6rem;font-weight:700;margin-bottom:.5rem}fieldset{border-width:0;padding:0}input[type='checkbox'],input[type='radio']{display:inline}.label-inline{display:inline-block;font-weight:normal;margin-left:.5rem}.row{display:flex;flex-direction:column;padding:0;width:100%}.row.row-no-padding{padding:0}.row.row-no-padding>.column{padding:0}.row.row-wrap{flex-wrap:wrap}.row.row-top{align-items:flex-start}.row.row-bottom{align-items:flex-end}.row.row-center{align-items:center}.row.row-stretch{align-items:stretch}.row.row-baseline{align-items:baseline}.row .column{display:block;flex:1 1 auto;margin-left:0;max-width:100%;width:100%}.row .column.column-offset-10{margin-left:10%}.row .column.column-offset-20{margin-left:20%}.row .column.column-offset-25{margin-left:25%}.row .column.column-offset-33,.row .column.column-offset-34{margin-left:33.3333%}.row .column.column-offset-50{margin-left:50%}.row .column.column-offset-66,.row .column.column-offset-67{margin-left:66.6666%}.row .column.column-offset-75{margin-left:75%}.row .column.column-offset-80{margin-left:80%}.row .column.column-offset-90{margin-left:90%}.row .column.column-10{flex:0 0 10%;max-width:10%}.row .column.column-20{flex:0 0 20%;max-width:20%}.row .column.column-25{flex:0 0 25%;max-width:25%}.row .column.column-33,.row .column.column-34{flex:0 0 33.3333%;max-width:33.3333%}.row .column.column-40{flex:0 0 40%;max-width:40%}.row .column.column-50{flex:0 0 50%;max-width:50%}.row .column.column-60{flex:0 0 60%;max-width:60%}.row .column.column-66,.row .column.column-67{flex:0 0 66.6666%;max-width:66.6666%}.row .column.column-75{flex:0 0 75%;max-width:75%}.row .column.column-80{flex:0 0 80%;max-width:80%}.row .column.column-90{flex:0 0 90%;max-width:90%}.row .column .column-top{align-self:flex-start}.row .column .column-bottom{align-self:flex-end}.row .column .column-center{-ms-grid-row-align:center;align-self:center}@media (min-width: 40rem){.row{flex-direction:row;margin-left:-1.0rem;width:calc(100%)}.row .column{margin-bottom:inherit;padding:0 1.0rem}}a{color:#0069d9;text-decoration:none}a:focus,a:hover{color:#606c76}dl,ol,ul{list-style:none;margin-top:0;padding-left:0}dl dl,dl ol,dl ul,ol dl,ol ol,ol ul,ul dl,ul ol,ul ul{font-size:90%;margin:1.5rem 0 1.5rem 3.0rem}ol{list-style:decimal inside}ul{list-style:circle inside}.button,button,dd,dt,li{margin-bottom:1.0rem}fieldset,input,select,textarea{margin-bottom:1.5rem}blockquote,dl,figure,form,ol,p,pre,table,ul{margin-bottom:2.5rem}table{border-spacing:0;width:100%}td,th{border-bottom:0.1rem solid #e1e1e1;padding:1.2rem 1.5rem;text-align:left}td:first-child,th:first-child{padding-left:0}td:last-child,th:last-child{padding-right:0}b,strong{font-weight:bold}p{margin-top:0}h1,h2,h3,h4,h6{font-weight:300;letter-spacing:-.1rem;margin-bottom:2.0rem;margin-top:0}h1{font-size:4.6rem;line-height:1.2}h2{font-size:3.6rem;line-height:1.25}h3{font-size:2.8rem;line-height:1.3}h4{font-size:2.2rem;letter-spacing:-.08rem;line-height:1.35}h5{font-size:1.8rem;letter-spacing:-.05rem;line-height:1.5}h6{font-size:1.6rem;letter-spacing:0;line-height:1.4}img{max-width:100%}.clearfix:after{clear:both;content:' ';display:table}.float-left{float:left}.float-right{float:right}
+*,
+*:after,
+*:before {
+  box-sizing: inherit
+}
+
+html {
+  box-sizing: border-box;
+  font-size: 62.5%
+}
+
+body {
+  color: #000000;
+  font-family: 'Helvetica', 'Arial', sans-serif;
+  font-size: 1.6em;
+  font-weight: 300;
+  line-height: 1.6
+}
+
+blockquote {
+  border-left: 0.3rem solid #d1d1d1;
+  margin-left: 0;
+  margin-right: 0;
+  padding: 1rem 1.5rem
+}
+
+blockquote *:last-child {
+  margin-bottom: 0
+}
+
+.button,
+button,
+input[type='button'],
+input[type='reset'],
+input[type='submit'] {
+  background-color: #0069d9;
+  border: 0.1rem solid #0069d9;
+  border-radius: .4rem;
+  color: #fff;
+  cursor: pointer;
+  display: inline-block;
+  font-size: 1.1rem;
+  font-weight: 700;
+  height: 3.8rem;
+  letter-spacing: .1rem;
+  line-height: 3.8rem;
+  padding: 0 3.0rem;
+  text-align: center;
+  text-decoration: none;
+  text-transform: uppercase;
+  white-space: nowrap
+}
+
+.button:hover,
+button:hover,
+input[type='button']:focus,
+input[type='button']:hover,
+input[type='reset']:focus,
+input[type='reset']:hover,
+input[type='submit']:focus,
+input[type='submit']:hover {
+  background-color: #606c76;
+  border-color: #606c76;
+  color: #fff;
+  outline: 0
+}
+
+.button[disabled],
+button[disabled],
+input[type='button'][disabled],
+input[type='reset'][disabled],
+input[type='submit'][disabled] {
+  cursor: default;
+  opacity: .5
+}
+
+.button[disabled]:focus,
+.button[disabled]:hover,
+button[disabled]:focus,
+button[disabled]:hover,
+input[type='button'][disabled]:focus,
+input[type='button'][disabled]:hover,
+input[type='reset'][disabled]:focus,
+input[type='reset'][disabled]:hover,
+input[type='submit'][disabled]:focus,
+input[type='submit'][disabled]:hover {
+  background-color: #0069d9;
+  border-color: #0069d9
+}
+
+.button.button-outline,
+button.button-outline,
+input[type='button'].button-outline,
+input[type='reset'].button-outline,
+input[type='submit'].button-outline {
+  background-color: transparent;
+  color: #0069d9
+}
+
+.button.button-outline:focus,
+.button.button-outline:hover,
+button.button-outline:focus,
+button.button-outline:hover,
+input[type='button'].button-outline:focus,
+input[type='button'].button-outline:hover,
+input[type='reset'].button-outline:focus,
+input[type='reset'].button-outline:hover,
+input[type='submit'].button-outline:focus,
+input[type='submit'].button-outline:hover {
+  background-color: transparent;
+  border-color: #606c76;
+  color: #606c76
+}
+
+.button.button-outline[disabled]:focus,
+.button.button-outline[disabled]:hover,
+button.button-outline[disabled]:focus,
+button.button-outline[disabled]:hover,
+input[type='button'].button-outline[disabled]:focus,
+input[type='button'].button-outline[disabled]:hover,
+input[type='reset'].button-outline[disabled]:focus,
+input[type='reset'].button-outline[disabled]:hover,
+input[type='submit'].button-outline[disabled]:focus,
+input[type='submit'].button-outline[disabled]:hover {
+  border-color: inherit;
+  color: #0069d9
+}
+
+.button.button-clear,
+button.button-clear,
+input[type='button'].button-clear,
+input[type='reset'].button-clear,
+input[type='submit'].button-clear {
+  background-color: transparent;
+  border-color: transparent;
+  color: #0069d9
+}
+
+.button.button-clear:focus,
+.button.button-clear:hover,
+button.button-clear:focus,
+button.button-clear:hover,
+input[type='button'].button-clear:focus,
+input[type='button'].button-clear:hover,
+input[type='reset'].button-clear:focus,
+input[type='reset'].button-clear:hover,
+input[type='submit'].button-clear:focus,
+input[type='submit'].button-clear:hover {
+  background-color: transparent;
+  border-color: transparent;
+  color: #606c76
+}
+
+.button.button-clear[disabled]:focus,
+.button.button-clear[disabled]:hover,
+button.button-clear[disabled]:focus,
+button.button-clear[disabled]:hover,
+input[type='button'].button-clear[disabled]:focus,
+input[type='button'].button-clear[disabled]:hover,
+input[type='reset'].button-clear[disabled]:focus,
+input[type='reset'].button-clear[disabled]:hover,
+input[type='submit'].button-clear[disabled]:focus,
+input[type='submit'].button-clear[disabled]:hover {
+  color: #0069d9
+}
+
+code {
+  background: #f4f5f6;
+  border-radius: .4rem;
+  font-size: 86%;
+  margin: 0 .2rem;
+  padding: .2rem .5rem;
+  white-space: nowrap
+}
+
+pre {
+  background: #f4f5f6;
+  border-left: 0.3rem solid #0069d9;
+  overflow-y: hidden
+}
+
+pre>code {
+  border-radius: 0;
+  display: block;
+  padding: 1rem 1.5rem;
+  white-space: pre
+}
+
+hr {
+  border: 0;
+  border-top: 0.1rem solid #f4f5f6;
+  margin: 3.0rem 0
+}
+
+input[type='email'],
+input[type='number'],
+input[type='password'],
+input[type='search'],
+input[type='tel'],
+input[type='text'],
+input[type='url'],
+textarea,
+select {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  background-color: transparent;
+  border: 0.1rem solid #d1d1d1;
+  border-radius: .4rem;
+  box-shadow: none;
+  box-sizing: inherit;
+  height: 3.8rem;
+  padding: .6rem 1.0rem;
+  width: 100%
+}
+
+input[type='email']:focus,
+input[type='number']:focus,
+input[type='password']:focus,
+input[type='search']:focus,
+input[type='tel']:focus,
+input[type='text']:focus,
+input[type='url']:focus,
+textarea:focus,
+select:focus {
+  border-color: #0069d9;
+  outline: 0
+}
+
+select {
+  background: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" height="14" viewBox="0 0 29 14" width="29"><path fill="%23d1d1d1" d="M9.37727 3.625l5.08154 6.93523L19.54036 3.625"/></svg>') center right no-repeat;
+  padding-right: 3.0rem
+}
+
+select:focus {
+  background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" height="14" viewBox="0 0 29 14" width="29"><path fill="%230069d9" d="M9.37727 3.625l5.08154 6.93523L19.54036 3.625"/></svg>')
+}
+
+textarea {
+  min-height: 6.5rem
+}
+
+label,
+legend {
+  display: block;
+  font-size: 1.6rem;
+  font-weight: 700;
+  margin-bottom: .5rem
+}
+
+fieldset {
+  border-width: 0;
+  padding: 0
+}
+
+input[type='checkbox'],
+input[type='radio'] {
+  display: inline
+}
+
+.label-inline {
+  display: inline-block;
+  font-weight: normal;
+  margin-left: .5rem
+}
+
+.row {
+  display: flex;
+  flex-direction: column;
+  padding: 0;
+  width: 100%
+}
+
+.row.row-no-padding {
+  padding: 0
+}
+
+.row.row-no-padding>.column {
+  padding: 0
+}
+
+.row.row-wrap {
+  flex-wrap: wrap
+}
+
+.row.row-top {
+  align-items: flex-start
+}
+
+.row.row-bottom {
+  align-items: flex-end
+}
+
+.row.row-center {
+  align-items: center
+}
+
+.row.row-stretch {
+  align-items: stretch
+}
+
+.row.row-baseline {
+  align-items: baseline
+}
+
+.row .column {
+  display: block;
+  flex: 1 1 auto;
+  margin-left: 0;
+  max-width: 100%;
+  width: 100%
+}
+
+.row .column.column-offset-10 {
+  margin-left: 10%
+}
+
+.row .column.column-offset-20 {
+  margin-left: 20%
+}
+
+.row .column.column-offset-25 {
+  margin-left: 25%
+}
+
+.row .column.column-offset-33,
+.row .column.column-offset-34 {
+  margin-left: 33.3333%
+}
+
+.row .column.column-offset-50 {
+  margin-left: 50%
+}
+
+.row .column.column-offset-66,
+.row .column.column-offset-67 {
+  margin-left: 66.6666%
+}
+
+.row .column.column-offset-75 {
+  margin-left: 75%
+}
+
+.row .column.column-offset-80 {
+  margin-left: 80%
+}
+
+.row .column.column-offset-90 {
+  margin-left: 90%
+}
+
+.row .column.column-10 {
+  flex: 0 0 10%;
+  max-width: 10%
+}
+
+.row .column.column-20 {
+  flex: 0 0 20%;
+  max-width: 20%
+}
+
+.row .column.column-25 {
+  flex: 0 0 25%;
+  max-width: 25%
+}
+
+.row .column.column-33,
+.row .column.column-34 {
+  flex: 0 0 33.3333%;
+  max-width: 33.3333%
+}
+
+.row .column.column-40 {
+  flex: 0 0 40%;
+  max-width: 40%
+}
+
+.row .column.column-50 {
+  flex: 0 0 50%;
+  max-width: 50%
+}
+
+.row .column.column-60 {
+  flex: 0 0 60%;
+  max-width: 60%
+}
+
+.row .column.column-66,
+.row .column.column-67 {
+  flex: 0 0 66.6666%;
+  max-width: 66.6666%
+}
+
+.row .column.column-75 {
+  flex: 0 0 75%;
+  max-width: 75%
+}
+
+.row .column.column-80 {
+  flex: 0 0 80%;
+  max-width: 80%
+}
+
+.row .column.column-90 {
+  flex: 0 0 90%;
+  max-width: 90%
+}
+
+.row .column .column-top {
+  align-self: flex-start
+}
+
+.row .column .column-bottom {
+  align-self: flex-end
+}
+
+.row .column .column-center {
+  -ms-grid-row-align: center;
+  align-self: center
+}
+
+@media (min-width: 40rem) {
+  .row {
+    flex-direction: row;
+    margin-left: -1.0rem;
+    width: calc(100%)
+  }
+
+  .row .column {
+    margin-bottom: inherit;
+    padding: 0 1.0rem
+  }
+}
+
+a {
+  color: #0069d9;
+  text-decoration: none
+}
+
+a:focus,
+a:hover {
+  color: #606c76
+}
+
+dl,
+ol,
+ul {
+  list-style: none;
+  margin-top: 0;
+  padding-left: 0
+}
+
+dl dl,
+dl ol,
+dl ul,
+ol dl,
+ol ol,
+ol ul,
+ul dl,
+ul ol,
+ul ul {
+  font-size: 90%;
+  margin: 1.5rem 0 1.5rem 3.0rem
+}
+
+ol {
+  list-style: decimal inside
+}
+
+ul {
+  list-style: circle inside
+}
+
+.button,
+button,
+dd,
+dt,
+li {
+  margin-bottom: 1.0rem
+}
+
+fieldset,
+input,
+select,
+textarea {
+  margin-bottom: 1.5rem
+}
+
+blockquote,
+dl,
+figure,
+form,
+ol,
+p,
+pre,
+table,
+ul {
+  margin-bottom: 2.5rem
+}
+
+table {
+  border-spacing: 0;
+  width: 100%
+}
+
+td,
+th {
+  border-bottom: 0.1rem solid #e1e1e1;
+  padding: 1.2rem 1.5rem;
+  text-align: left
+}
+
+td:first-child,
+th:first-child {
+  padding-left: 0
+}
+
+td:last-child,
+th:last-child {
+  padding-right: 0
+}
+
+b,
+strong {
+  font-weight: bold
+}
+
+p {
+  margin-top: 0
+}
+
+h1,
+h2,
+h3,
+h4,
+h6 {
+  font-weight: 300;
+  letter-spacing: -.1rem;
+  margin-bottom: 2.0rem;
+  margin-top: 0
+}
+
+h1 {
+  font-size: 4.6rem;
+  line-height: 1.2
+}
+
+h2 {
+  font-size: 3.6rem;
+  line-height: 1.25
+}
+
+h3 {
+  font-size: 2.8rem;
+  line-height: 1.3
+}
+
+h4 {
+  font-size: 2.2rem;
+  letter-spacing: -.08rem;
+  line-height: 1.35
+}
+
+h5 {
+  font-size: 1.8rem;
+  letter-spacing: -.05rem;
+  line-height: 1.5
+}
+
+h6 {
+  font-size: 1.6rem;
+  letter-spacing: 0;
+  line-height: 1.4
+}
+
+img {
+  max-width: 100%
+}
+
+.clearfix:after {
+  clear: both;
+  content: ' ';
+  display: table
+}
+
+.float-left {
+  float: left
+}
+
+.float-right {
+  float: right
+}
 
 /* General style */
-h1{font-size: 3.6rem; line-height: 1.25}
-h2{font-size: 2.8rem; line-height: 1.3}
-h3{font-size: 2.2rem; letter-spacing: -.08rem; line-height: 1.35}
-h4{font-size: 1.8rem; letter-spacing: -.05rem; line-height: 1.5}
-h5{font-size: 1.6rem; letter-spacing: 0; line-height: 1.4}
-h6{font-size: 1.4rem; letter-spacing: 0; line-height: 1.2}
-pre{padding: 1em;}
+h1 {
+  font-size: 3.6rem;
+  line-height: 1.25
+}
 
-.container{
+h2 {
+  font-size: 2.8rem;
+  line-height: 1.3
+}
+
+h3 {
+  font-size: 2.2rem;
+  letter-spacing: -.08rem;
+  line-height: 1.35
+}
+
+h4 {
+  font-size: 1.8rem;
+  letter-spacing: -.05rem;
+  line-height: 1.5
+}
+
+h5 {
+  font-size: 1.6rem;
+  letter-spacing: 0;
+  line-height: 1.4
+}
+
+h6 {
+  font-size: 1.4rem;
+  letter-spacing: 0;
+  line-height: 1.2
+}
+
+pre {
+  padding: 1em;
+}
+
+.container {
   margin: 0 auto;
   padding: 0 2.0rem;
   position: relative;
   width: 80%
 }
+
 select {
   width: auto;
 }
@@ -38,14 +660,17 @@ select {
   font-weight: 200;
   font-size: 120%;
 }
+
 .phx-hero input {
   background: #ffffff;
 }
+
 .phx-logo {
   min-width: 300px;
   margin: 1rem;
   display: block;
 }
+
 .phx-logo img {
   width: auto;
   display: block;
@@ -58,18 +683,22 @@ header {
   border-bottom: 1px solid #eaeaea;
   margin-bottom: 2rem;
 }
+
 header section {
   align-items: center;
   display: flex;
   flex-direction: column;
   justify-content: space-between;
 }
+
 header section :first-child {
   order: 2;
 }
+
 header section :last-child {
   order: 1;
 }
+
 header nav ul,
 header nav li {
   margin: 0;
@@ -78,21 +707,27 @@ header nav li {
   text-align: right;
   white-space: nowrap;
 }
+
 header nav ul {
   margin: 1rem;
   margin-top: 0;
 }
+
 header nav a {
   display: block;
 }
 
-@media (min-width: 40.0rem) { /* Small devices (landscape phones, 576px and up) */
+@media (min-width: 40.0rem) {
+
+  /* Small devices (landscape phones, 576px and up) */
   header section {
     flex-direction: row;
   }
+
   header nav ul {
     margin: 1rem;
   }
+
   .phx-logo {
     flex-basis: 527px;
     margin: 2rem 1rem;
@@ -105,48 +740,55 @@ header nav a {
   padding: 15px;
   margin-bottom: 20px;
   border: 1px solid transparent;
-  border-radius: 4px; }
+  border-radius: 4px;
+}
 
 .alert-info {
   color: #31708f;
   background-color: #d9edf7;
-  border-color: #bce8f1; }
+  border-color: #bce8f1;
+}
 
 .alert-warning {
   color: #8a6d3b;
   background-color: #fcf8e3;
-  border-color: #faebcc; }
+  border-color: #faebcc;
+}
 
 .alert-danger {
   color: #a94442;
   background-color: #f2dede;
-  border-color: #ebccd1; }
+  border-color: #ebccd1;
+}
 
 .alert p {
-  margin-bottom: 0; }
+  margin-bottom: 0;
+}
 
 .alert:empty {
-  display: none; }
+  display: none;
+}
 
 .invalid-feedback {
   color: #a94442;
   display: block;
-  margin: -1rem 0 2rem; }
+  margin: -1rem 0 2rem;
+}
 
 .poll-item {
-	margin: 2%;
-	padding: 2%;
-	border: 1px solid lightgray;
-	border-radius: 12px;
+  margin: 2%;
+  padding: 2%;
+  border: 1px solid lightgray;
+  border-radius: 12px;
 }
 
 .radio-label {
-	display: inline;
-	padding-right: 12px;
+  display: inline;
+  padding-right: 12px;
 }
 
 .remove-item-button {
-	font-size: 8px;
-	text-align:center;
-	float: right;
+  font-size: 8px;
+  text-align: center;
+  float: right;
 }

--- a/priv/static/css/character/weapons.css
+++ b/priv/static/css/character/weapons.css
@@ -33,18 +33,13 @@ hr {
 }
 
 .flash-border {
-    position: relative;
+    z-index: 2;
+    outline: gold 4px solid !important;
+    outline-offset: -4px;
 }
 
-.flash-border:after {
-    width: 100%;
-    height: 100%;
-    content: '';
-    outline: gold 10px solid !important;
-    outline-offset: -10px;
-    position: absolute;
-    top: 0;
-    left: 0;
+.flash-border>td {
+    z-index: -1;
 }
 
 .weapon {

--- a/priv/static/css/character/weapons.css
+++ b/priv/static/css/character/weapons.css
@@ -56,6 +56,19 @@ hr {
     width: auto;
 }
 
+.weapon-image-container,
+.weaponName,
+.weapon>.th-inner {
+    border-left: 1px solid #dee2e6;
+    border-right: 1px solid #dee2e6;
+}
+
+.weapon,
+.table {
+    border-left-width: 0px !important;
+}
+
+
 .w-33 {
     width: 33.3333%
 }

--- a/priv/static/css/character/weapons.css
+++ b/priv/static/css/character/weapons.css
@@ -15,27 +15,6 @@
     }
 }
 
-.contains-disabled-input,
-input[disabled] + span > p,
-input[disabled] + span,
-input[disabled]:hover {
-    color: #ccc;
-    cursor: not-allowed!important;
-}
-
-.bootstrap-table{
-    padding-bottom: 10px;
-}
-
-.dropdown-item:hover,
-input:hover{
-    cursor: pointer;
-}
-
-.dropdown-item{
-    margin-bottom: 0;
-}
-
 hr{
     height: 1px;
     width: 80%;
@@ -43,111 +22,11 @@ hr{
     background-color: rgb(110, 110, 110);
     border: none;
 }
-
-#filterDropdownMenu{
-    max-height: 400px;
-    max-width: 570px;
-    min-width: 300px;
-    overflow: auto;
-}
-
-.flexed-filter-options-container{
-  width: 96%;
-  margin: auto;
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-}
-.dropdown-menu{
-  background-color: #eeeeee;
-}
-.filter-option{
-    width: 100%;
-}
-.small-filter-option{
-    width: 50%;
-}
 #weaponTable-clear-filter-button{
     position: absolute;
     right: 0;
     background-color: #d9534f;
     border-color: #d9534f;
-}
-.filter-option-contains{
-    color: rgb(110, 110, 110);
-    font-size: smaller;
-    padding-left: 4px;
-}
-/*Contained <hr/> needs strange styling to flow properly*/
-.middle-hr{
-    width: 85%;
-    margin-left: 10%;
-}
-@media only screen and (max-width: 660px) {
-    .middle-hr{
-        width: 86%;
-    }
-}
-@media only screen and (max-width: 600px) {
-    .middle-hr{
-        width: 87.5%;
-    }
-}
-@media only screen and (max-width: 575px) {
-    .middle-hr{
-        width: 88.5%;
-    }
-}
-@media only screen and (max-width: 475px) {
-    .middle-hr{
-        width: 90%;
-    }
-}
-
-@media only screen and (min-width: 768px) { /*for boostrap > xs*/
-    .table th:first-child,
-    .table td:first-child{
-        position: sticky;
-        top: 0;
-        left: 0;
-    }
-    .table th:first-child{
-        background-color: #ffffff;
-    }
-    .table tr:nth-child(odd) td:first-child{
-        background-color: #eeeeee;
-    }
-    .table tr:nth-child(even) td:first-child{
-        background-color: #ffffff;
-    }
-    tbody tr:hover, tbody tr:hover > td:first-child {
-        background-color: #dddddd!important;
-    }
-
-    .filter-option{
-        width: 50%;
-    }
-    #leftSideFilterContainer{
-        padding-right: 0;
-        border-right: 1px solid rgb(110, 110, 110);
-    }
-
-    .filter-option{
-        width: 50%;
-    }
-    .large-filter-option{
-        width: 100%;
-    }
-}
-
-tbody tr.selection, 
-tbody tr.selection > td:first-child {
-    background-color: #dddddd!important;
-}
-
-.selection{
-    position: relative;
-    border: gold 2px solid!important;
 }
 
 .flash-border{
@@ -162,84 +41,4 @@ tbody tr.selection > td:first-child {
   position: absolute;
   top: 0;
   left: 0;
-}
-
-.search-input, .search-input:hover{
-    font-size: medium;
-    cursor: text;
-}
-@media only screen and (max-width: 767px) { /*for boostrap xs*/
-    .search-input{
-        font-size: small;
-    }
-}
-.context-menu-help{
-    color: rgb(110, 110, 110);
-    font-size: small;
-    padding-left: 80px;
-}
-#weaponTable-copy-link:hover,
-#weaponTable-copy-link:hover .context-menu-help{
-    color: white;
-    background-color: #9B84EE;
-    cursor: pointer;
-}
-
-#weaponTable{
-  -moz-user-select: none;
-  -webkit-user-select: none;
-  -ms-user-select: none;
-  -o-user-select: none;
-  user-select: none; 
-}
-
-@media only screen and (max-width: 767px) { /*for boostrap xs*/
-    #weaponTable-copy-link{
-        padding: 0;
-        padding-left: 10px!important;
-    }
-}
-
-.toast{
-    color: white;
-    background-color: #727272;
-    border-radius: 25px;
-    position:fixed;
-    top: 50%;
-    left: 50%;
-    cursor: default;
-}
-
-tr.selection.main-selected,
-tbody tr.selection.main-selected > td:first-child{
-    background-color: #d9544f54!important;
-}
-
-.fixed-table-body::-webkit-scrollbar {
-    -webkit-appearance: none;
-}
-
-.fixed-table-body::-webkit-scrollbar:vertical {
-    width: 12px;
-}
-
-.fixed-table-body::-webkit-scrollbar:horizontal {
-    height: 12px;
-}
-
-.fixed-table-body::-webkit-scrollbar-thumb {
-    background-color: rgba(0, 0, 0, .5);
-    border-radius: 10px;
-    border: 2px solid #ffffff;
-    display: block;
-    position: absolute;
-    top: 50%;
-}
-
-.fixed-table-body::-webkit-scrollbar-track {
-    border-radius: 10px;  
-    background-color: #ffffff; 
-    display: block;
-    position: absolute;
-    top: 50%;
 }

--- a/priv/static/css/character/weapons.css
+++ b/priv/static/css/character/weapons.css
@@ -147,16 +147,7 @@ tbody tr.selection > td:first-child {
 
 .selection{
     position: relative;
-}
-.selection:after {
-  width: 100%;
-  height: 100%;
-  content: '';
-  outline: gold 2px solid!important;
-  outline-offset: -2px;
-  position: absolute;
-  top: 0;
-  left: 0;
+    border: gold 2px solid!important;
 }
 
 .flash-border{
@@ -187,15 +178,23 @@ tbody tr.selection > td:first-child {
     font-size: small;
     padding-left: 80px;
 }
-#copyWeaponLink:hover,
-#copyWeaponLink:hover .context-menu-help{
+#weaponTable-copy-link:hover,
+#weaponTable-copy-link:hover .context-menu-help{
     color: white;
     background-color: #9B84EE;
     cursor: pointer;
 }
 
+#weaponTable{
+  -moz-user-select: none;
+  -webkit-user-select: none;
+  -ms-user-select: none;
+  -o-user-select: none;
+  user-select: none; 
+}
+
 @media only screen and (max-width: 767px) { /*for boostrap xs*/
-    #copyWeaponLink{
+    #weaponTable-copy-link{
         padding: 0;
         padding-left: 10px!important;
     }
@@ -209,4 +208,38 @@ tbody tr.selection > td:first-child {
     top: 50%;
     left: 50%;
     cursor: default;
+}
+
+tr.selection.main-selected,
+tbody tr.selection.main-selected > td:first-child{
+    background-color: #d9544f54!important;
+}
+
+.fixed-table-body::-webkit-scrollbar {
+    -webkit-appearance: none;
+}
+
+.fixed-table-body::-webkit-scrollbar:vertical {
+    width: 12px;
+}
+
+.fixed-table-body::-webkit-scrollbar:horizontal {
+    height: 12px;
+}
+
+.fixed-table-body::-webkit-scrollbar-thumb {
+    background-color: rgba(0, 0, 0, .5);
+    border-radius: 10px;
+    border: 2px solid #ffffff;
+    display: block;
+    position: absolute;
+    top: 50%;
+}
+
+.fixed-table-body::-webkit-scrollbar-track {
+    border-radius: 10px;  
+    background-color: #ffffff; 
+    display: block;
+    position: absolute;
+    top: 50%;
 }

--- a/priv/static/css/character/weapons.css
+++ b/priv/static/css/character/weapons.css
@@ -42,3 +42,26 @@ hr{
   top: 0;
   left: 0;
 }
+
+.w-33{
+    width:33.3333%
+}
+.menu-item{
+    padding-left: 20px;
+}
+.selection-mobile-menu-top,
+.selection-mobile-menu-bottom{
+    position: fixed;
+    left: 0;
+    z-index: 1021;
+    height: 50px;
+    width: 100%;
+    background-color: rgba(34, 34, 34, .9);
+    color: rgb(218, 218, 218);
+}
+.selection-mobile-menu-top{
+    top: 0;
+}
+.selection-mobile-menu-bottom{
+    bottom: 170px;
+}

--- a/priv/static/css/character/weapons.css
+++ b/priv/static/css/character/weapons.css
@@ -1,67 +1,65 @@
-.aurax-progress{
-    background-color: #c29ffa!important;
+.aurax-progress {
+    background-color: #c29ffa !important;
 }
 
-#nextAurax{
+#nextAurax {
     position: relative;
     -webkit-box-flex: 0;
     -ms-flex: 0 1 auto;
     flex: 0 1 auto;
 }
 
-@media only screen and (min-width: 768px) { /*for boostrap > xs*/
-    nav{
+@media only screen and (min-width: 768px) {
+
+    /*for boostrap > xs*/
+    nav {
         opacity: 1;
     }
 }
 
-hr{
+hr {
     height: 1px;
     width: 80%;
     margin: 0 auto 12px auto;
     background-color: rgb(110, 110, 110);
     border: none;
 }
-#weaponTable-clear-filter-button{
+
+#weaponTable-clear-filter-button {
     position: absolute;
     right: 0;
     background-color: #d9534f;
     border-color: #d9534f;
 }
 
-.flash-border{
+.flash-border {
     position: relative;
 }
+
 .flash-border:after {
-  width: 100%;
-  height: 100%;
-  content: '';
-  outline: gold 10px solid!important;
-  outline-offset: -10px;
-  position: absolute;
-  top: 0;
-  left: 0;
+    width: 100%;
+    height: 100%;
+    content: '';
+    outline: gold 10px solid !important;
+    outline-offset: -10px;
+    position: absolute;
+    top: 0;
+    left: 0;
 }
 
-.w-33{
-    width:33.3333%
+.weapon {
+    min-width: 150px;
 }
-.menu-item{
+
+.weapon-image {
+    height: 75px;
+    width: auto;
+}
+
+.w-33 {
+    width: 33.3333%
+}
+
+.menu-item {
     padding-left: 20px;
-}
-.selection-mobile-menu-top,
-.selection-mobile-menu-bottom{
-    position: fixed;
-    left: 0;
-    z-index: 1021;
-    height: 50px;
-    width: 100%;
-    background-color: rgba(34, 34, 34, .9);
-    color: rgb(218, 218, 218);
-}
-.selection-mobile-menu-top{
-    top: 0;
-}
-.selection-mobile-menu-bottom{
-    bottom: 170px;
 }

--- a/priv/static/css/flex-bootstrap-table-filter.css
+++ b/priv/static/css/flex-bootstrap-table-filter.css
@@ -1,0 +1,106 @@
+.contains-disabled-input,
+input[disabled] + span > p,
+input[disabled] + span,
+input[disabled]:hover {
+    color: #ccc;
+    cursor: not-allowed!important;
+}
+
+#filterDropdownMenu{
+    max-height: 400px;
+    max-width: 570px;
+    min-width: 300px;
+    overflow: auto;
+}
+
+.flexed-filter-options-container{
+  width: 96%;
+  margin: auto;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+}
+.filter-option{
+    width: 100%;
+}
+.small-filter-option{
+    width: 50%;
+}
+
+.filter-option-contains{
+    color: rgb(110, 110, 110);
+    font-size: smaller;
+    padding-left: 4px;
+}
+
+/*Contained <hr/> needs strange styling to flow properly*/
+.middle-hr{
+    width: 85%;
+    margin-left: 10%;
+}
+@media only screen and (max-width: 660px) {
+    .middle-hr{
+        width: 86%;
+    }
+}
+@media only screen and (max-width: 600px) {
+    .middle-hr{
+        width: 87.5%;
+    }
+}
+@media only screen and (max-width: 575px) {
+    .middle-hr{
+        width: 88.5%;
+    }
+}
+@media only screen and (max-width: 475px) {
+    .middle-hr{
+        width: 90%;
+    }
+}
+
+@media only screen and (min-width: 768px) { /*for boostrap > xs*/
+    .filter-option{
+        width: 50%;
+    }
+    #leftSideFilterContainer{
+        padding-right: 0;
+        border-right: 1px solid rgb(110, 110, 110);
+    }
+
+    .filter-option{
+        width: 50%;
+    }
+    .large-filter-option{
+        width: 100%;
+    }
+}
+
+.fixed-table-body::-webkit-scrollbar {
+    -webkit-appearance: none;
+}
+
+.fixed-table-body::-webkit-scrollbar:vertical {
+    width: 12px;
+}
+
+.fixed-table-body::-webkit-scrollbar:horizontal {
+    height: 12px;
+}
+
+.fixed-table-body::-webkit-scrollbar-thumb {
+    background-color: rgba(0, 0, 0, .5);
+    border-radius: 10px;
+    border: 2px solid #ffffff;
+    display: block;
+    position: absolute;
+    top: 50%;
+}
+
+.fixed-table-body::-webkit-scrollbar-track {
+    border-radius: 10px;  
+    background-color: #ffffff; 
+    display: block;
+    position: absolute;
+    top: 50%;
+}

--- a/priv/static/css/flex-bootstrap-table-selection.css
+++ b/priv/static/css/flex-bootstrap-table-selection.css
@@ -1,0 +1,51 @@
+tbody tr.selection, 
+tbody tr.selection > td:first-child {
+    background-color: #dddddd!important;
+}
+
+.selection{
+    position: relative;
+    border: gold 2px solid!important;
+}
+
+.table{
+    -moz-user-select: none;
+    -webkit-user-select: none;
+    -ms-user-select: none;
+    -o-user-select: none;
+    user-select: none; 
+}
+
+.table-context-menu-help{
+    color: rgb(110, 110, 110);
+    font-size: small;
+    padding-left: 80px;
+}
+#table-copy-link:hover,
+#table-copy-link:hover .context-menu-help{
+    color: white;
+    background-color: #9B84EE;
+    cursor: pointer;
+}
+
+@media only screen and (max-width: 767px) { /*for boostrap xs*/
+    #table-copy-link{
+        padding: 0;
+        padding-left: 10px!important;
+    }
+}
+
+.toast{
+    color: white;
+    background-color: #727272;
+    border-radius: 25px;
+    position:fixed;
+    top: 50%;
+    left: 50%;
+    cursor: default;
+}
+
+tr.selection.main-selected,
+tbody tr.selection.main-selected > td:first-child{
+    background-color: #d9544f54!important;
+}

--- a/priv/static/css/flex-bootstrap-table-selection.css
+++ b/priv/static/css/flex-bootstrap-table-selection.css
@@ -5,7 +5,17 @@ tbody tr.selection>td:first-child {
 
 .selection {
     position: relative;
-    border: gold 2px solid !important;
+}
+
+.selection:after {
+    width: 100%;
+    height: 100%;
+    content: '';
+    outline: gold 4px solid !important;
+    outline-offset: -4px;
+    position: absolute;
+    top: 0;
+    left: 0;
 }
 
 .table {

--- a/priv/static/css/flex-bootstrap-table-selection.css
+++ b/priv/static/css/flex-bootstrap-table-selection.css
@@ -1,21 +1,15 @@
-tbody tr.selection,
-tbody tr.selection>td:first-child {
+tbody tr.selection>td {
     background-color: #dddddd !important;
 }
 
 .selection {
-    position: relative;
-}
-
-.selection:after {
-    width: 100%;
-    height: 100%;
-    content: '';
+    z-index: 2;
     outline: gold 4px solid !important;
     outline-offset: -4px;
-    position: absolute;
-    top: 0;
-    left: 0;
+}
+
+.selection>td {
+    z-index: -1;
 }
 
 .table {
@@ -66,8 +60,7 @@ tbody tr.selection>td:first-child {
     cursor: default;
 }
 
-tr.selection.main-selected,
-tbody tr.selection.main-selected>td:first-child {
+tbody tr.selection.main-selected>td {
     background-color: #b8b8b8 !important;
 }
 

--- a/priv/static/css/flex-bootstrap-table-selection.css
+++ b/priv/static/css/flex-bootstrap-table-selection.css
@@ -1,56 +1,81 @@
-tbody tr.selection, 
-tbody tr.selection > td:first-child {
-    background-color: #dddddd!important;
+tbody tr.selection,
+tbody tr.selection>td:first-child {
+    background-color: #dddddd !important;
 }
 
-.selection{
+.selection {
     position: relative;
-    border: gold 2px solid!important;
+    border: gold 2px solid !important;
 }
 
-.table{
+.table {
     -moz-user-select: none;
     -webkit-user-select: none;
     -ms-user-select: none;
     -o-user-select: none;
-    user-select: none; 
+    user-select: none;
 }
-#table-context-menu{
+
+#table-context-menu {
     width: 300px;
 }
-.context-menu-help{
+
+.context-menu-help {
     color: rgb(110, 110, 110);
     font-size: small;
 }
+
 .context-menu-row:hover,
-.context-menu-row:hover .context-menu-help{
+.context-menu-row:hover .context-menu-help {
     color: white;
     background-color: #9B84EE;
     cursor: pointer;
 }
-.context-menu-row{
+
+.context-menu-row {
     margin-left: 0;
 }
 
-@media only screen and (max-width: 767px) { /*for boostrap xs*/
+@media only screen and (max-width: 767px) {
+
+    /*for boostrap xs*/
     #table-copy-link,
-    #table-copy-text{
+    #table-copy-text {
         padding: 0;
-        padding-left: 10px!important;
+        padding-left: 10px !important;
     }
 }
 
-.toast{
+.toast {
     color: white;
     background-color: #727272;
     border-radius: 25px;
-    position:fixed;
+    position: fixed;
     top: 50%;
     left: 50%;
     cursor: default;
 }
 
 tr.selection.main-selected,
-tbody tr.selection.main-selected > td:first-child{
-    background-color: #b8b8b8!important;
+tbody tr.selection.main-selected>td:first-child {
+    background-color: #b8b8b8 !important;
+}
+
+.selection-mobile-menu-top,
+.selection-mobile-menu-bottom {
+    position: fixed;
+    left: 0;
+    z-index: 1021;
+    height: 50px;
+    width: 100%;
+    background-color: rgba(34, 34, 34, .9);
+    color: rgb(218, 218, 218);
+}
+
+.selection-mobile-menu-top {
+    top: 0;
+}
+
+.selection-mobile-menu-bottom {
+    bottom: 170px;
 }

--- a/priv/static/css/flex-bootstrap-table-selection.css
+++ b/priv/static/css/flex-bootstrap-table-selection.css
@@ -47,5 +47,5 @@ tbody tr.selection > td:first-child {
 
 tr.selection.main-selected,
 tbody tr.selection.main-selected > td:first-child{
-    background-color: #d9544f54!important;
+    background-color: #b8b8b8!important;
 }

--- a/priv/static/css/flex-bootstrap-table-selection.css
+++ b/priv/static/css/flex-bootstrap-table-selection.css
@@ -15,21 +15,26 @@ tbody tr.selection > td:first-child {
     -o-user-select: none;
     user-select: none; 
 }
-
-.table-context-menu-help{
+#table-context-menu{
+    width: 300px;
+}
+.context-menu-help{
     color: rgb(110, 110, 110);
     font-size: small;
-    padding-left: 80px;
 }
-#table-copy-link:hover,
-#table-copy-link:hover .context-menu-help{
+.context-menu-row:hover,
+.context-menu-row:hover .context-menu-help{
     color: white;
     background-color: #9B84EE;
     cursor: pointer;
 }
+.context-menu-row{
+    margin-left: 0;
+}
 
 @media only screen and (max-width: 767px) { /*for boostrap xs*/
-    #table-copy-link{
+    #table-copy-link,
+    #table-copy-text{
         padding: 0;
         padding-left: 10px!important;
     }

--- a/priv/static/css/flex-bootstrap-table.css
+++ b/priv/static/css/flex-bootstrap-table.css
@@ -41,6 +41,10 @@
         float: left\9;
         width: 100%;
     }
+
+    .bootstrap-table {
+        padding-bottom: 500px;
+    }
 }
 
 .bootstrap-table {

--- a/priv/static/css/flex-bootstrap-table.css
+++ b/priv/static/css/flex-bootstrap-table.css
@@ -5,6 +5,14 @@
     min-width: 300px;
 }
 
+.progress-bar-background {
+    background-color: rgba(194, 194, 194, 0.9);
+}
+
+.medal {
+    background: radial-gradient(rgba(0, 0, 0, 0.9), rgba(0, 0, 0, 0) 70%);
+}
+
 @media screen and (max-width: 767px) {
 
     /*for boostrap xs*/

--- a/priv/static/css/flex-bootstrap-table.css
+++ b/priv/static/css/flex-bootstrap-table.css
@@ -82,8 +82,11 @@ input:not(input[type=text]):not(input[type=search]):hover {
         background-color: #ffffff;
     }
 
-    tbody tr:hover,
-    tbody tr:hover>td:first-child {
+    .table tr.selected td:first-child {
+        background-color: #ffffff;
+    }
+
+    tbody tr:hover>td {
         background-color: #dddddd !important;
     }
 }

--- a/priv/static/css/flex-bootstrap-table.css
+++ b/priv/static/css/flex-bootstrap-table.css
@@ -86,8 +86,16 @@ input:not(input[type=text]):not(input[type=search]):hover {
         background-color: #ffffff;
     }
 
-    tbody tr:hover>td {
+    tbody tr:not(tr.selection):hover>td {
         background-color: #dddddd !important;
+    }
+
+    tr.selection:hover {
+        background-color: rgba(0, 0, 0, 0) !important;
+    }
+
+    tr.selection {
+        background-color: rgba(0, 0, 0, 0) !important;
     }
 }
 

--- a/priv/static/css/flex-bootstrap-table.css
+++ b/priv/static/css/flex-bootstrap-table.css
@@ -1,0 +1,77 @@
+@import "flex-bootstrap-table-filter.css";
+
+.table-responsive-stack .table-responsive-stack-thead {
+    font-weight: bold;
+    min-width: 300px;
+}
+
+@media screen and (max-width: 767px) { /*for boostrap xs*/
+    td:first-child{
+        padding-left: 7.5px;
+    }
+    .table-responsive-stack td, .table-responsive-stack th {
+        display:block;
+        -ms-flex: 1 1 auto;
+        flex: 1 1 auto;
+    }
+    .table-responsive-stack tr {
+        -webkit-box-orient: vertical;
+        -webkit-box-direction: normal;
+        -ms-flex-direction: column;
+        flex-direction: column;
+        border-bottom: 3px solid #ccc; /*row splitting line info*/
+        display:block;
+    }
+    .table-responsive-stack td {
+        float: left\9;
+        width:100%;
+    }
+}
+
+.bootstrap-table{
+    padding-bottom: 10px;
+}
+
+.dropdown-item:hover,
+input:hover{
+    cursor: pointer;
+}
+
+.dropdown-item{
+    margin-bottom: 0;
+}
+
+.dropdown-menu{
+    background-color: #eeeeee;
+}
+
+@media only screen and (min-width: 768px) { /*for boostrap > xs*/
+    .table th:first-child,
+    .table td:first-child{
+        position: sticky;
+        top: 0;
+        left: 0;
+    }
+    .table th:first-child{
+        background-color: #ffffff;
+    }
+    .table tr:nth-child(odd) td:first-child{
+        background-color: #eeeeee;
+    }
+    .table tr:nth-child(even) td:first-child{
+        background-color: #ffffff;
+    }
+    tbody tr:hover, tbody tr:hover > td:first-child {
+        background-color: #dddddd!important;
+    }
+}
+
+.search-input, .search-input:hover{
+    font-size: medium;
+    cursor: text;
+}
+@media only screen and (max-width: 767px) { /*for boostrap xs*/
+    .search-input{
+        font-size: small;
+    }
+}

--- a/priv/static/css/flex-bootstrap-table.css
+++ b/priv/static/css/flex-bootstrap-table.css
@@ -5,73 +5,91 @@
     min-width: 300px;
 }
 
-@media screen and (max-width: 767px) { /*for boostrap xs*/
-    td:first-child{
+@media screen and (max-width: 767px) {
+
+    /*for boostrap xs*/
+    td:first-child {
         padding-left: 7.5px;
     }
-    .table-responsive-stack td, .table-responsive-stack th {
-        display:block;
+
+    .table-responsive-stack td,
+    .table-responsive-stack th {
+        display: block;
         -ms-flex: 1 1 auto;
         flex: 1 1 auto;
     }
+
     .table-responsive-stack tr {
         -webkit-box-orient: vertical;
         -webkit-box-direction: normal;
         -ms-flex-direction: column;
         flex-direction: column;
-        border-bottom: 3px solid #ccc; /*row splitting line info*/
-        display:block;
+        border-bottom: 3px solid #ccc;
+        /*row splitting line info*/
+        display: block;
     }
+
     .table-responsive-stack td {
         float: left\9;
-        width:100%;
+        width: 100%;
     }
 }
 
-.bootstrap-table{
+.bootstrap-table {
     padding-bottom: 10px;
 }
 
 .dropdown-item:hover,
-input:hover{
+input:hover {
     cursor: pointer;
 }
 
-.dropdown-item{
+.dropdown-item {
     margin-bottom: 0;
 }
 
-.dropdown-menu{
+.dropdown-menu {
     background-color: #eeeeee;
 }
 
-@media only screen and (min-width: 768px) { /*for boostrap > xs*/
+@media only screen and (min-width: 768px) {
+
+    /*for boostrap > xs*/
     .table th:first-child,
-    .table td:first-child{
+    .table td:first-child {
         position: sticky;
         top: 0;
         left: 0;
     }
-    .table th:first-child{
+
+    .table th:first-child {
         background-color: #ffffff;
     }
-    .table tr:nth-child(odd) td:first-child{
+
+    .table tr:nth-child(odd) td:first-child {
         background-color: #eeeeee;
     }
-    .table tr:nth-child(even) td:first-child{
+
+    .table tr:nth-child(even) td:first-child {
         background-color: #ffffff;
     }
-    tbody tr:hover, tbody tr:hover > td:first-child {
-        background-color: #dddddd!important;
+
+    tbody tr:hover,
+    tbody tr:hover>td:first-child {
+        background-color: #dddddd !important;
     }
 }
 
-.search-input, .search-input:hover{
+.search-input,
+.search-input:hover {
     font-size: medium;
     cursor: text;
 }
-@media only screen and (max-width: 767px) { /*for boostrap xs*/
-    .search-input{
+
+@media only screen and (max-width: 767px) {
+
+    /*for boostrap xs*/
+    .search-input {
         font-size: small;
     }
 }

--- a/priv/static/css/flex-bootstrap-table.css
+++ b/priv/static/css/flex-bootstrap-table.css
@@ -40,7 +40,7 @@
 }
 
 .dropdown-item:hover,
-input:hover {
+input:not(input[type=text]):not(input[type=search]):hover {
     cursor: pointer;
 }
 
@@ -80,10 +80,8 @@ input:hover {
     }
 }
 
-.search-input,
-.search-input:hover {
+.search-input {
     font-size: medium;
-    cursor: text;
 }
 
 @media only screen and (max-width: 767px) {

--- a/priv/static/css/styles.css
+++ b/priv/static/css/styles.css
@@ -1,28 +1,32 @@
 @import "flex-bootstrap-table.css";
 
 /*General*/
-footer{
-  z-index:99;
+footer {
+  z-index: 99;
 }
-.smooth-transition-three{
+
+.smooth-transition-three {
   transition: .3s;
 }
-figure{
-  margin-bottom: 0!important;
+
+figure {
+  margin-bottom: 0 !important;
 }
+
 #back-to-top {
   position: fixed;
   bottom: 20px;
   right: 20px;
   display: none;
-  z-index:99;
+  z-index: 99;
   width: 60px;
   height: 60px;
   padding: 8px 12px;
   border-radius: 30px;
   font-size: 11px;
 }
-@media screen and (max-width: 767px){
+
+@media screen and (max-width: 767px) {
   #back-to-top {
     bottom: 220px;
     width: 50px;
@@ -33,11 +37,14 @@ figure{
     text-align: center;
   }
 }
-@media (min-width: 2100px){
+
+@media (min-width: 2100px) {
   .container {
-      max-width: 1920px;
+    max-width: 1920px;
   }
-  .progress, .progress > div {
+
+  .progress,
+  .progress>div {
     height: 30px;
   }
 }
@@ -48,67 +55,86 @@ figure{
   text-align: center;
   padding-left: 20px;
 }
+
 .navbar-nav {
   padding: 20px;
   padding-bottom: 0px;
 }
-.second-nav{
+
+.second-nav {
   position: -webkit-sticky;
   position: sticky;
-  top:167px;
+  top: 167px;
   z-index: 1020;
 }
-nav{
+
+nav {
   opacity: 0.94;
 }
+
 .navbar-expand-md .navbar-collapse {
   flex-direction: column;
   align-items: flex-end;
 }
-.top-bottom-nav{
+
+.top-bottom-nav {
   transition: .3s;
 }
-.sticky-top{
+
+.sticky-top {
   margin-bottom: 0px;
 }
-.active-page{
+
+.active-page {
   border-bottom: 3px solid gold;
   transition: .5s;
 }
-.active-subpage{
+
+.active-subpage {
   border-bottom: 3px solid gold;
   transition: .5s;
 }
+
 /*individual hover colors*/
-ul.navbar-nav li:not(.active-page):not(.active-subpage){
-  box-sizing:border-box;
+ul.navbar-nav li:not(.active-page):not(.active-subpage) {
+  box-sizing: border-box;
   border-bottom: 3px solid transparent;
   transition: .5s;
 }
-ul.navbar-nav li:hover, ul.navbar-nav li:hover > a.moving-nav-link {  
-  margin-top:-10px;
+
+ul.navbar-nav li:hover,
+ul.navbar-nav li:hover>a.moving-nav-link {
+  margin-top: -10px;
   transition: .2s;
 }
-ul.navbar-nav li:hover, ul.navbar-nav li{  
+
+ul.navbar-nav li:hover,
+ul.navbar-nav li {
   height: 100%;
 }
-ul.navbar-nav li:hover, ul.navbar-nav li:hover > a.static-nav-link {  
+
+ul.navbar-nav li:hover,
+ul.navbar-nav li:hover>a.static-nav-link {
   margin-top: 0px;
   transition: 0s;
 }
-ul.navbar-nav li:hover:nth-child(4n+1) {  
+
+ul.navbar-nav li:hover:nth-child(4n+1) {
   border-bottom: 3px solid #9370DB;
   color: #9370DB;
 }
-ul.navbar-nav li:hover:nth-child(4n+2) {  
+
+ul.navbar-nav li:hover:nth-child(4n+2) {
   border-bottom: 3px solid #1E90FF;
   color: #1E90FF;
 }
-ul.navbar-nav li:hover:nth-child(4n+3) {  
+
+ul.navbar-nav li:hover:nth-child(4n+3) {
   border-bottom: 3px solid #CD5C5C;
   color: #CD5C5C;
 }
-ul.navbar-nav li:hover:nth-child(4n+4) {  
+
+ul.navbar-nav li:hover:nth-child(4n+4) {
   border-bottom: 3px solid #716857;
   color: #716857;
 }
@@ -117,8 +143,11 @@ ul.navbar-nav li:hover:nth-child(4n+4) {
 .pb-26 {
   padding-bottom: 26rem !important;
 }
-@media only screen and (max-width: 767px) { /*for boostrap xs*/
-  .main-content{
+
+@media only screen and (max-width: 767px) {
+
+  /*for boostrap xs*/
+  .main-content {
     padding-bottom: 10rem !important;
   }
 }
@@ -131,22 +160,26 @@ ul.navbar-nav li:hover:nth-child(4n+4) {
   top: 0;
   left: 0;
   background-color: #15181d;
-  display:flex;
+  display: flex;
   justify-content: center;
   align-items: center;
   z-index: 9999;
 }
-#loading-screen-text{
+
+#loading-screen-text {
   color: #aebfdb;
 }
+
 .rotate {
   animation: rotation 1.2s infinite linear;
 }
+
 .hide-loading-screen {
   visibility: hidden;
   opacity: 0;
   transition: visibility 0s .2s, opacity .2s linear;
 }
+
 .show-loading-screen {
   visibility: visible;
   opacity: 1;
@@ -157,6 +190,7 @@ ul.navbar-nav li:hover:nth-child(4n+4) {
   from {
     transform: rotate(0deg);
   }
+
   to {
     transform: rotate(359deg);
   }

--- a/priv/static/css/styles.css
+++ b/priv/static/css/styles.css
@@ -1,3 +1,5 @@
+@import "flex-bootstrap-table.css";
+
 /*General*/
 footer{
   z-index:99;
@@ -157,34 +159,5 @@ ul.navbar-nav li:hover:nth-child(4n+4) {
   }
   to {
     transform: rotate(359deg);
-  }
-}
-
-/* Table Styles */
-.table-responsive-stack .table-responsive-stack-thead {
-  font-weight: bold;
-  min-width: 300px;
-}
-
-@media screen and (max-width: 767px) {
-  td:first-child{
-    padding-left: 7.5px;
-  }
-  .table-responsive-stack td, .table-responsive-stack th {
-    display:block;
-    -ms-flex: 1 1 auto;
-    flex: 1 1 auto;
-  }
-  .table-responsive-stack tr {
-    -webkit-box-orient: vertical;
-    -webkit-box-direction: normal;
-    -ms-flex-direction: column;
-    flex-direction: column;
-    border-bottom: 3px solid #ccc; /*row splitting line info*/
-    display:block;
-  }
-  .table-responsive-stack td {
-    float: left\9;
-    width:100%;
   }
 }

--- a/priv/static/js/character/weapons-table.js
+++ b/priv/static/js/character/weapons-table.js
@@ -77,18 +77,18 @@ function addCustomCopyFunction() {
     let customFunction = function () {
         //get the current url
         const newURL = new URL(window.location.href);
+        newURL.search = "?";
 
         //if there is only 1 selection add the weapon name to the search arg
         let copyRows = bootstrapSelection.getSelectedRows();
         if (copyRows.size == 1) {
-            newURL.search = "?search=";
+            newURL.search = newURL.search + "search=";
             copyRows.forEach(row => {
                 newURL.search = newURL.search + $(row).find("td.weapon").first().find("h5.weaponName").first()[0].innerHTML.replaceAll(" ", "_");
             });
             newURL.search = newURL.search + "&";
-        } else {
-            newURL.search = "?";
         }
+
         //add each selected id to the id arg separated by ','
         newURL.search = newURL.search + "id=" + [...copyRows][0].id.replaceAll("weapon", "").replaceAll("Row", "");
         for (let i = 1; i < copyRows.size; i++) {

--- a/priv/static/js/character/weapons-table.js
+++ b/priv/static/js/character/weapons-table.js
@@ -119,7 +119,7 @@ function addCustomCopyFunction() {
                 if (i > 1) {
                     copyString = copyString + ", ";
                 }
-                copyString = copyString + headerArray[i].innerText + ": " + dataArray[i].innerText;
+                copyString = copyString + (isMobileScreen() ? "" : (headerArray[i].innerText + ": ")) + dataArray[i].innerText;
             }
 
             //create new line space between each weapon stat
@@ -157,6 +157,10 @@ function flashElement(elementId) {
         window.clearInterval(flashInterval);
         $("#" + elementId).removeClass("flash-border");
     }, 1000);
+}
+
+function isMobileScreen() {
+    return window.innerWidth <= 767;
 }
 
 export function showHideNextAuraxButton() {

--- a/priv/static/js/character/weapons-table.js
+++ b/priv/static/js/character/weapons-table.js
@@ -135,7 +135,7 @@ function addCustomCopyFunction() {
     };
 
     bootstrapSelection.setCustomCopyFunction(customFunction);
-    //bootstrapSelection.setCustomCopyFunction(customCopyFunction);
+    bootstrapSelection.setSecondCustomCopyFunction(customCopyFunction);
 }
 
 function initializeButtonEvent() {

--- a/priv/static/js/character/weapons-table.js
+++ b/priv/static/js/character/weapons-table.js
@@ -80,19 +80,18 @@ function addCustomCopyFunction() {
         newURL.search = "?";
 
         //if there is only 1 selection add the weapon name to the search arg
-        let copyRows = bootstrapSelection.getSelectedRows();
-        if (copyRows.size == 1) {
+        let copyRows = [...bootstrapSelection.getSelectedRows()];
+        let firstCopyElement = copyRows[0];
+        if (copyRows.length == 1) {
             newURL.search = newURL.search + "search=";
-            copyRows.forEach(row => {
-                newURL.search = newURL.search + $(row).find("td.weapon").first().find("h5.weaponName").first()[0].innerHTML.replaceAll(" ", "_");
-            });
+            newURL.search = newURL.search + $(firstCopyElement).find("td.weapon").first().find("h5.weaponName").first()[0].innerHTML.replaceAll(" ", "_");
             newURL.search = newURL.search + "&";
         }
 
         //add each selected id to the id arg separated by ','
-        newURL.search = newURL.search + "id=" + [...copyRows][0].id.replaceAll("weapon", "").replaceAll("Row", "");
-        for (let i = 1; i < copyRows.size; i++) {
-            newURL.search = newURL.search + "," + [...copyRows][i].id.replaceAll("weapon", "").replaceAll("Row", "");
+        newURL.search = newURL.search + "id=" + firstCopyElement.id.replaceAll("weapon", "").replaceAll("Row", "");
+        for (let i = 1; i < copyRows.length; i++) {
+            newURL.search = newURL.search + "," + copyRows[i].id.replaceAll("weapon", "").replaceAll("Row", "");
         }
 
         //return the new url

--- a/priv/static/js/character/weapons-table.js
+++ b/priv/static/js/character/weapons-table.js
@@ -1,7 +1,6 @@
 import { nextAuraxElementID } from "/js/character/weapons.js";
 import * as bootstrapTableFilter from "/js/flex-bootstrap-table-filter.js";
-
-let copyRows = new Set();
+import * as bootstrapSelection from "/js/flex-bootstrap-table-selection.js";
 
 window.addEventListener('load', (event) => {
     if (window.innerWidth >= 768) {
@@ -74,6 +73,33 @@ function addCustomFilters() {
     bootstrapTableFilter.setCustomFilterFunctions(customFunction);
 }
 
+function addCustomCopyFunction() {
+    let customFunction = function () {
+        //get the current url
+        const newURL = new URL(window.location.href);
+
+        //if there is only 1 selection add the weapon name to the search arg
+        let copyRows = bootstrapSelection.getSelectedRows();
+        newURL.search = "?search=";
+        if (copyRows.size == 1) {
+            copyRows.forEach(row => {
+                newURL.search = newURL.search + $(row).find("td.weapon").first().find("h5.weaponName").first()[0].innerHTML.replaceAll(" ", "_");
+            });
+        }
+
+        //add each selected id to the id arg separated by ','
+        newURL.search = newURL.search + "&id=" + [...copyRows][0].id.replaceAll("weapon", "").replaceAll("Row", "");
+        for (let i = 1; i < copyRows.size; i++) {
+            newURL.search = newURL.search + "," + [...copyRows][i].id.replaceAll("weapon", "").replaceAll("Row", "");
+        }
+
+        //copy the new url to clipboard and reset selection
+        return newURL;
+    }
+
+    //bootstrapSelection.setCustomCopyFunction(customFunction);
+}
+
 function initializeButtonEvent() {
     document.getElementById("nextAurax").addEventListener('click', function () {
         $('html, body').animate({
@@ -93,141 +119,6 @@ function flashElement(elementId) {
         window.clearInterval(flashInterval);
         $("#" + elementId).removeClass("flash-border");
     }, 1000);
-}
-
-function addRightClickTable() {
-    //add special Right click on table menu
-    $('#weaponTable').on('contextmenu', function (e) {
-        //initialize special menu location
-        var top = ((e.clientY / $(window).height()) * 100) + "%";
-        var left = ((e.clientX / $(window).width()) * 100) + "%";
-
-        //show special menu at the bottom right of the mouse
-        $("#context-menu").css({
-            display: "block",
-            position: "fixed",
-            top: top,
-            left: left
-        }).addClass("show");
-
-        //if the row was not selected before deselect other selected rows
-        let row = $(e.target).closest("tr")[0];
-        if (!copyRows.has(row)) {
-            resetCopyRowSelection();
-        }
-
-        //add current row to selection
-        copyRows.add(row);
-        $(e.target).closest("tr").addClass("selection");
-
-        return false; //blocks default Webbrowser right click menu
-    });
-
-    //update selections
-    $('#weaponTable').on('click', function (e) {
-        //hide the special menu and initialize variables
-        hideContextMenu();
-
-        //make sure it's only weapon rows being clicked
-        let row = $(e.target).closest("tr")[0];
-        if (row.id.includes("weapon")) {
-            //if it's a new selection set reset the selections
-            if (copyRows.size > 0 && !e.ctrlKey) {
-                resetCopyRowSelection();
-            }
-
-            //disable on-click selection for mobile
-            if (window.innerWidth > 767) {
-                //if the ctrl key was pressed while a selection was clicked remove it
-                if (e.ctrlKey && copyRows.has(row)) {
-                    copyRows.delete(row);
-                    $(row).removeClass("selection");
-                } else {
-                    //otherwise just add the current row to selection
-                    copyRows.add(row);
-                    $(e.target).closest("tr").addClass("selection");
-                }
-            }
-        } else {
-            resetCopyRowSelection();
-        }
-    });
-
-    //add event listner for copy click
-    $("#copyWeaponLink").on('click', function () {
-        $('.toast').toast('show');
-        hideContextMenu();
-    });
-
-    //add page click events
-    $(document).on("click", function (e) {
-        //if the click is not in the table remove selections and hide the special menu
-        if ($(e.target).closest("tr")[0] == undefined || $(e.target).closest("tr")[0].localName != "tr") {
-            resetCopyRowSelection();
-            hideContextMenu();
-        }
-    });
-
-    //add page key events
-    $(document).on("keyup", function (e) {
-        //if the user presses ctrl-C with something selected copy selected rows
-        if (e.key === 'c' && e.ctrlKey && copyRows.size > 0) {
-            copySelectedRows();
-            $('.toast').toast('show');
-        }
-    });
-
-    //add page right click events to hide special menu
-    $(document).on("contextmenu", function () {
-        hideContextMenu();
-    });
-
-    //hide the special menu when an option is clicked
-    $("#context-menu").on("click", function () {
-        hideContextMenu();
-    });
-
-    //add copy clicks
-    addCopyClick();
-}
-
-function resetCopyRowSelection() {
-    //remove the selection style from each row and reinit the set
-    copyRows.forEach(row => {
-        $(row).removeClass("selection");
-    });
-    copyRows = new Set();
-}
-
-function hideContextMenu() {
-    $("#context-menu").removeClass("show").hide();
-}
-
-function addCopyClick() {
-    $("#copyWeaponLink").on('click', copySelectedRows);
-}
-
-function copySelectedRows() {
-    //get the current url
-    const newURL = new URL(window.location.href);
-
-    //if there is only 1 selection add the weapon name to the search arg
-    newURL.search = "?search=";
-    if (copyRows.size == 1) {
-        copyRows.forEach(row => {
-            newURL.search = newURL.search + $(row).find("td.weapon").first().find("h5.weaponName").first()[0].innerHTML.replaceAll(" ", "_");
-        });
-    }
-
-    //add each selected id to the id arg separated by ','
-    newURL.search = newURL.search + "&id=" + [...copyRows][0].id.replaceAll("weapon", "").replaceAll("Row", "");
-    for (let i = 1; i < copyRows.size; i++) {
-        newURL.search = newURL.search + "," + [...copyRows][i].id.replaceAll("weapon", "").replaceAll("Row", "");
-    }
-
-    //copy the new url to clipboard and reset selection
-    navigator.clipboard.writeText(newURL);
-    resetCopyRowSelection();
 }
 
 export function showHideNextAuraxButton() {
@@ -259,5 +150,5 @@ export default function init() {
 
     initializeButtonEvent();
     addCustomFilters();
-    addRightClickTable();
+    addCustomCopyFunction();
 }

--- a/priv/static/js/character/weapons-table.js
+++ b/priv/static/js/character/weapons-table.js
@@ -80,21 +80,23 @@ function addCustomCopyFunction() {
 
         //if there is only 1 selection add the weapon name to the search arg
         let copyRows = bootstrapSelection.getSelectedRows();
-        newURL.search = "?search=";
         if (copyRows.size == 1) {
+            newURL.search = "?search=";
             copyRows.forEach(row => {
                 newURL.search = newURL.search + $(row).find("td.weapon").first().find("h5.weaponName").first()[0].innerHTML.replaceAll(" ", "_");
             });
+            newURL.search = newURL.search.replaceAll('%22', '\"') + "&";
+        } else {
+            newURL.search = "?";
         }
-
         //add each selected id to the id arg separated by ','
-        newURL.search = newURL.search + "&id=" + [...copyRows][0].id.replaceAll("weapon", "").replaceAll("Row", "");
+        newURL.search = newURL.search + "id=" + [...copyRows][0].id.replaceAll("weapon", "").replaceAll("Row", "");
         for (let i = 1; i < copyRows.size; i++) {
             newURL.search = newURL.search + "," + [...copyRows][i].id.replaceAll("weapon", "").replaceAll("Row", "");
         }
 
         //return the new url
-        return newURL;
+        return newURL.toString().replaceAll('%22', '\"');
     };
 
     let customCopyFunction = function () {
@@ -133,8 +135,8 @@ function addCustomCopyFunction() {
         return copyString;
     };
 
-    //bootstrapSelection.setCustomCopyFunction(customFunction);
-    bootstrapSelection.setCustomCopyFunction(customCopyFunction);
+    bootstrapSelection.setCustomCopyFunction(customFunction);
+    //bootstrapSelection.setCustomCopyFunction(customCopyFunction);
 }
 
 function initializeButtonEvent() {

--- a/priv/static/js/character/weapons-table.js
+++ b/priv/static/js/character/weapons-table.js
@@ -85,7 +85,7 @@ function addCustomCopyFunction() {
             copyRows.forEach(row => {
                 newURL.search = newURL.search + $(row).find("td.weapon").first().find("h5.weaponName").first()[0].innerHTML.replaceAll(" ", "_");
             });
-            newURL.search = newURL.search.replaceAll('%22', '\"') + "&";
+            newURL.search = newURL.search + "&";
         } else {
             newURL.search = "?";
         }

--- a/priv/static/js/character/weapons-table.js
+++ b/priv/static/js/character/weapons-table.js
@@ -175,20 +175,8 @@ export function showHideNextAuraxButton() {
 
 export default function init() {
     $('#weaponTable').bootstrapTable({
-        formatSearch: function () {
-            return 'Search Weapon Name'
-        },
-        customSearch: searchByWeaponName,
         dragaccept: '.drag-accept'
     });
-
-    function searchByWeaponName(data, text) {
-        return bootstrapTableFilter.sortData(data.filter(function (row) {
-            var template = document.createElement('template');
-            template.innerHTML = row.weapon;
-            return template.content.querySelector(".weaponName").innerHTML.toLowerCase().indexOf(text.toLowerCase()) > -1;
-        }));
-    }
 
     initializeButtonEvent();
     addCustomFilters();

--- a/priv/static/js/character/weapons-table.js
+++ b/priv/static/js/character/weapons-table.js
@@ -93,11 +93,48 @@ function addCustomCopyFunction() {
             newURL.search = newURL.search + "," + [...copyRows][i].id.replaceAll("weapon", "").replaceAll("Row", "");
         }
 
-        //copy the new url to clipboard and reset selection
+        //return the new url
         return newURL;
-    }
+    };
+
+    let customCopyFunction = function () {
+        //create a header line
+        let copyString = document.getElementById("characterName").innerText + "'s Weapon Stats\n\n";
+
+        //initialize variables
+        let headerArray = [...$('#weaponTable').find('thead').first().find('tr').first()[0].children];
+        let index = 0;
+        let copyRows = bootstrapSelection.getSelectedRows();
+
+        //loop through each selected weapon row
+        copyRows.forEach(row => {
+            let dataArray = $(row).find('td');
+
+            //create a weapon subheader
+            copyString = copyString + dataArray[0].innerText.split("\n")[0] + " (" + row.id.replaceAll("weapon", "").replaceAll("Row", "") + "):\n";
+
+            //loop through each coloumn and separate them by commas and property values by colons
+            for (let i = 1; i < dataArray.length; i++) {
+                if (i > 1) {
+                    copyString = copyString + ", ";
+                }
+                copyString = copyString + headerArray[i].innerText + ": " + dataArray[i].innerText;
+            }
+
+            //create new line space between each weapon stat
+            if (index < copyRows.size - 1) {
+                copyString = copyString + "\n\n";
+                index++;
+            }
+
+        });
+
+        //return the copy string
+        return copyString;
+    };
 
     //bootstrapSelection.setCustomCopyFunction(customFunction);
+    bootstrapSelection.setCustomCopyFunction(customCopyFunction);
 }
 
 function initializeButtonEvent() {

--- a/priv/static/js/flex-bootstrap-table-filter.js
+++ b/priv/static/js/flex-bootstrap-table-filter.js
@@ -103,7 +103,7 @@ function initializeSearchInput() {
             //get the query object that has the id
             textArray.find(text => {
                 if (text.includes("id=")) {
-                    //get the id and filter the data based on that and the weapon name
+                    //get the id and filter the data based on that and the search key
                     let ids = text.split("=")[1].split(",");
                     filterByIds(ids);
                 }

--- a/priv/static/js/flex-bootstrap-table-filter.js
+++ b/priv/static/js/flex-bootstrap-table-filter.js
@@ -420,9 +420,11 @@ function setNextAuraxVisibilities() {
     }, 10);
 }
 
-function refreshByScroll() {
-    window.scrollBy(0, -1);
-    window.scrollBy(0, 1);
+function initializeStickyHeaderWidths() {
+    let top = JSON.parse(JSON.stringify(document.body.scrollTop));
+    document.body.scrollTop = 0;
+    setStickyHeaderWidths();
+    document.body.scrollTop = top;
 }
 
 export function setStickyHeaderWidths() {
@@ -430,9 +432,10 @@ export function setStickyHeaderWidths() {
     let columns = document.querySelector(tableID + ">tbody>tr").querySelectorAll("td");
     for (let i = 0; i < headers.length; i++) {
         let width = $(columns[i]).width();
-        headers[i].style.width = (width + "px");
+        $(headers[i]).css({
+            'width': width + 'px'
+        });
     }
-    refreshByScroll();
 }
 
 export function updateTableFiltration() {
@@ -584,6 +587,7 @@ export function init(id) {
 
     //set up filter option data and event listeners
     initializeSearchInput();
+    initializeStickyHeaderWidths();
     updateTableFiltration();
     addFilterListeners();
     updateFilterOptionAvailability();

--- a/priv/static/js/flex-bootstrap-table-filter.js
+++ b/priv/static/js/flex-bootstrap-table-filter.js
@@ -420,6 +420,11 @@ function setNextAuraxVisibilities() {
     }, 10);
 }
 
+function refreshByScroll() {
+    window.scrollBy(0, -1);
+    window.scrollBy(0, 1);
+}
+
 export function setStickyHeaderWidths() {
     let headers = document.querySelector("thead.sticky-header > tr").querySelectorAll("th");
     let columns = document.querySelector(tableID + ">tbody>tr").querySelectorAll("td");
@@ -427,6 +432,7 @@ export function setStickyHeaderWidths() {
         let width = $(columns[i]).width();
         headers[i].style.width = (width + "px");
     }
+    refreshByScroll();
 }
 
 export function updateTableFiltration() {

--- a/priv/static/js/flex-bootstrap-table-filter.js
+++ b/priv/static/js/flex-bootstrap-table-filter.js
@@ -400,7 +400,7 @@ function isThereAFilterSet() {
     return false;
 }
 
-function showHideClearFilterButtons() {
+export function showHideClearFilterButtons() {
     if (isThereAFilterSet()) {
         $(clearFilterButtonID).show();
         $(clearAllFilterButtonID).show();
@@ -418,6 +418,15 @@ function setNextAuraxVisibilities() {
     setTimeout(function () {
         showHideNextAuraxButton();
     }, 10);
+}
+
+export function setStickyHeaderWidths() {
+    let headers = document.querySelector("thead.sticky-header > tr").querySelectorAll("th");
+    let columns = document.querySelector(tableID + ">tbody>tr").querySelectorAll("td");
+    for (let i = 0; i < headers.length; i++) {
+        let width = $(columns[i]).width();
+        headers[i].style.width = (width + "px");
+    }
 }
 
 export function updateTableFiltration() {
@@ -489,6 +498,7 @@ function applyFormatsToTable() {
         addAnimationToProgressBars();
         addFormatsToPage();
         setMobileHeaderTexts(getTableID().substring(1));
+        setStickyHeaderWidths();
     }, 10);
 }
 

--- a/priv/static/js/flex-bootstrap-table-filter.js
+++ b/priv/static/js/flex-bootstrap-table-filter.js
@@ -77,7 +77,7 @@ function initializeSearchInput() {
     let query = document.location.search;
 
     //if the query string is valid
-    if (query != "" && query.toLowerCase().startsWith("?search=")) {
+    if (query != "" && (query.toLowerCase().startsWith("?search=") || query.toLowerCase().startsWith("?id="))) {
         //clear filters to make search visible
         let persistentFiltersName = window.location.pathname + "/filterMap";
         localStorage.removeItem(persistentFiltersName);
@@ -85,10 +85,15 @@ function initializeSearchInput() {
         //get variables
         let search = query.substring(1);
         let searchElement = document.querySelector("input.search-input");
-        let searchText = search.split("&")[0].split("=")[1].replaceAll("%20", " ").replaceAll("+", " ").replaceAll("_", " ");
+        let searchText = getSearchTextFromSearchQuery(search);
 
         //determine if it will need a custom filter
-        if (!search.includes("&id=")) {
+        if (search.startsWith("id=")) {
+            //filter by ids present
+            searchText = "";
+            let ids = search.split("=")[1].split(",");
+            filterByIds(ids);
+        } else if (!search.includes("&id=")) {
             //simulate a search
             const ke = new KeyboardEvent('keydown', { keyCode: 13 });
             searchElement.dispatchEvent(ke);
@@ -100,17 +105,7 @@ function initializeSearchInput() {
                 if (text.includes("id=")) {
                     //get the id and filter the data based on that and the weapon name
                     let ids = text.split("=")[1].split(",");
-                    let filteredDataArray = getOriginalTableData().filter(function (row) {
-                        var template = document.createElement('template');
-                        template.innerHTML = row.weapon;
-                        return template.content.querySelector(".weaponName").innerHTML.toLowerCase().indexOf(searchText.toLowerCase()) > -1
-                            && ids.includes(row.id);
-                    })
-
-                    //set the new id and make sure to compensate for the new filtering
-                    $(getTableID()).bootstrapTable('load', filteredDataArray);
-                    hasID = true;
-                    idFilteredData = filteredDataArray;
+                    filterByIds(ids);
                 }
             });
         }
@@ -122,6 +117,22 @@ function initializeSearchInput() {
             document.querySelector("input.search-input").select();
         }
     }
+}
+
+function getSearchTextFromSearchQuery(searchQuery) {
+    return searchQuery.split("&")[0].split("=")[1].replaceAll("%20", " ").replaceAll('%22', '\"').replaceAll("+", " ").replaceAll("_", " ");
+}
+
+function filterByIds(ids) {
+    //filter original data based off of id
+    let filteredDataArray = getOriginalTableData().filter(function (row) {
+        return ids.includes(row.id.replaceAll("weapon", "").replaceAll("Row", ""));
+    })
+
+    //set the new id and make sure to compensate for the new filtering
+    $(getTableID()).bootstrapTable('load', filteredDataArray);
+    hasID = true;
+    idFilteredData = filteredDataArray;
 }
 
 function addFilterListeners() {

--- a/priv/static/js/flex-bootstrap-table-filter.js
+++ b/priv/static/js/flex-bootstrap-table-filter.js
@@ -1,4 +1,4 @@
-import { setMobileHeaderTexts, updateSearchParam } from "/js/flex-bootstrap-table.js";
+import { setMobileHeaderTexts, updateSearchParam, setStickyHeaderWidths } from "/js/flex-bootstrap-table.js";
 import { addFormatsToPage, addAnimationToProgressBars } from "/js/formats.js";
 import { showHideNextAuraxButton } from "/js/character/weapons-table.js";
 
@@ -420,32 +420,6 @@ function setNextAuraxVisibilities() {
     }, 10);
 }
 
-function initializeStickyHeaderWidths() {
-    //get the current scroll position and scroll to the top of the page
-    let top = JSON.parse(JSON.stringify(document.body.scrollTop));
-    document.body.scrollTop = 0;
-
-    //set the sticky header widths
-    setStickyHeaderWidths();
-
-    //reset the scroll position to the original
-    document.body.scrollTop = top;
-}
-
-export function setStickyHeaderWidths() {
-    //initialize variables
-    let headers = document.querySelector("thead.sticky-header > tr").querySelectorAll("th");
-    let columns = document.querySelector(tableID + ">tbody>tr").querySelectorAll("td");
-
-    //make sure each header matches it's matching td
-    for (let i = 0; i < headers.length; i++) {
-        let width = $(columns[i]).width();
-        $(headers[i]).css({
-            'width': width + 'px'
-        });
-    }
-}
-
 export function updateTableFiltration() {
     //make sure the table data and filtration are initialized
     accountForShowAlls();
@@ -595,7 +569,6 @@ export function init(id) {
 
     //set up filter option data and event listeners
     initializeSearchInput();
-    initializeStickyHeaderWidths();
     updateTableFiltration();
     addFilterListeners();
     updateFilterOptionAvailability();

--- a/priv/static/js/flex-bootstrap-table-filter.js
+++ b/priv/static/js/flex-bootstrap-table-filter.js
@@ -421,15 +421,23 @@ function setNextAuraxVisibilities() {
 }
 
 function initializeStickyHeaderWidths() {
+    //get the current scroll position and scroll to the top of the page
     let top = JSON.parse(JSON.stringify(document.body.scrollTop));
     document.body.scrollTop = 0;
+
+    //set the sticky header widths
     setStickyHeaderWidths();
+
+    //reset the scroll position to the original
     document.body.scrollTop = top;
 }
 
 export function setStickyHeaderWidths() {
+    //initialize variables
     let headers = document.querySelector("thead.sticky-header > tr").querySelectorAll("th");
     let columns = document.querySelector(tableID + ">tbody>tr").querySelectorAll("td");
+
+    //make sure each header matches it's matching td
     for (let i = 0; i < headers.length; i++) {
         let width = $(columns[i]).width();
         $(headers[i]).css({

--- a/priv/static/js/flex-bootstrap-table-selection.js
+++ b/priv/static/js/flex-bootstrap-table-selection.js
@@ -124,7 +124,7 @@ function addRightClickTable() {
 
     function handleAnchorClickEvents() {
         resetCopyRowSelection();
-        showHideSelectionMobileMenu();
+        $("." + mobileSelectionMenu).hide();
     }
     // function handlePageLinkClicks() {
     //     setTimeout(function () {

--- a/priv/static/js/flex-bootstrap-table-selection.js
+++ b/priv/static/js/flex-bootstrap-table-selection.js
@@ -124,7 +124,7 @@ function addRightClickTable() {
 
     function handleAnchorClickEvents() {
         resetCopyRowSelection();
-        $("." + mobileSelectionMenu).hide();
+        hideSelectionMobileMenu();
     }
     // function handlePageLinkClicks() {
     //     setTimeout(function () {
@@ -156,7 +156,7 @@ function addRightClickTable() {
         //if the click is not in the table remove selections and hide the special menu
         if ($(e.target).closest("table")[0] == undefined && !dragged && $(e.target).closest("." + mobileSelectionMenu)[0] == undefined) {
             resetCopyRowSelection(e);
-            $("." + mobileSelectionMenu).hide();
+            hideSelectionMobileMenu();
         }
     });
 
@@ -433,8 +433,13 @@ function showHideSelectionMobileMenu() {
     if (isMobileScreen() && !$("." + mobileSelectionMenu).is(":visible")) {
         $("." + mobileSelectionMenu).show();
     } else {
-        $("." + mobileSelectionMenu).hide();
+        hideSelectionMobileMenu();
     }
+}
+
+function hideSelectionMobileMenu() {
+    $("." + mobileSelectionMenu).hide();
+    document.getElementById(mobileSelectionMenu + "-select-all-btn").checked = false;
 }
 
 function getRowArrayIndex(row) {

--- a/priv/static/js/flex-bootstrap-table-selection.js
+++ b/priv/static/js/flex-bootstrap-table-selection.js
@@ -31,8 +31,9 @@ function addRightClickTable() {
 
         if (!isMobileScreen()) {
             //initialize special menu location
-            let yAdj = (e.clientY + $(contextMenuID).height() > $(window).height()) ? (e.clientY - $(contextMenuID).height() - 5) : e.clientY; //adjust height to show all of menu
-            let xAdj = (e.clientX + $(contextMenuID).width() > $(window).width()) ? (e.clientX - $(contextMenuID).width() - 2) : e.clientX; //adjust width to show all of menu
+            let isFireFox = navigator.userAgent.indexOf("Firefox") != -1;
+            let yAdj = (e.clientY + $(contextMenuID).height() > $(window).height()) ? (e.clientY - $(contextMenuID).height() - (isFireFox ? 0 : 5)) : e.clientY; //adjust height to show all of menu
+            let xAdj = (e.clientX + $(contextMenuID).width() > $(window).width()) ? (e.clientX - $(contextMenuID).width() - (isFireFox ? 0 : 2)) : e.clientX; //adjust width to show all of menu
             var top = ((yAdj / $(window).height()) * 100) + "%";
             var left = ((xAdj / $(window).width()) * 100) + "%";
 
@@ -117,9 +118,14 @@ function addRightClickTable() {
     });
 
     //add pagination events
-    $("a.dropdown-item").on("click", resetCopyRowSelection);
+    $("a.dropdown-item").on("click", handleAnchorClickEvents);
 
-    $('a.page-link').on('click', resetCopyRowSelection);
+    $('a.page-link').on('click', handleAnchorClickEvents);
+
+    function handleAnchorClickEvents() {
+        resetCopyRowSelection();
+        showHideSelectionMobileMenu();
+    }
     // function handlePageLinkClicks() {
     //     setTimeout(function () {
     //         rowArray = [...$(tableID).find("tbody").first()[0].children];
@@ -150,6 +156,7 @@ function addRightClickTable() {
         //if the click is not in the table remove selections and hide the special menu
         if ($(e.target).closest("table")[0] == undefined && !dragged && $(e.target).closest("." + mobileSelectionMenu)[0] == undefined) {
             resetCopyRowSelection(e);
+            $("." + mobileSelectionMenu).hide();
         }
     });
 
@@ -208,6 +215,7 @@ function addMobileSelectionMenuClickEvents() {
     //handle back button clicks
     backBtn.addEventListener("click", function (e) {
         resetCopyRowSelection(e);
+        showHideSelectionMobileMenu();
     });
 
     //handle select all clicks
@@ -243,7 +251,6 @@ function resetCopyRowSelection(e) {
         selectedRowIndex = undefined;
     }
     handleMobileMenu();
-    showHideSelectionMobileMenu();
 }
 
 function hideContextMenu() {
@@ -570,6 +577,7 @@ function copySelectedRows(e) {
     //copy the new url to clipboard and reset selection
     navigator.clipboard.writeText(copyString);
     resetCopyRowSelection(e);
+    showHideSelectionMobileMenu();
 }
 
 export function getSelectedRows() {

--- a/priv/static/js/flex-bootstrap-table-selection.js
+++ b/priv/static/js/flex-bootstrap-table-selection.js
@@ -125,6 +125,15 @@ function addRightClickTable() {
     function handleAnchorClickEvents() {
         resetCopyRowSelection();
         hideSelectionMobileMenu();
+
+        //make sure the anchor element keeps the listener
+        setTimeout(function () {
+            $("a.dropdown-item").off("click", handleAnchorClickEvents);
+            $("a.dropdown-item").on("click", handleAnchorClickEvents);
+
+            $('a.page-link').off('click', handleAnchorClickEvents);
+            $('a.page-link').on('click', handleAnchorClickEvents);
+        }, 1000);
     }
     // function handlePageLinkClicks() {
     //     setTimeout(function () {

--- a/priv/static/js/flex-bootstrap-table-selection.js
+++ b/priv/static/js/flex-bootstrap-table-selection.js
@@ -1,0 +1,426 @@
+//initialize variables
+let startRowIndex; //dragged main selection index
+let selectedRowIndex; //click main selection index
+let currentRowIndex; //last index pressed
+let prevRowIndex; //predicted previous index pressed
+let dragged = false;
+let upDown = false; //up is true down is false
+
+let mainSelectionClass = "main-selected";
+let selectionClass = "selection";
+let customCopyFunction;
+
+//selection helper lists
+let rowArray;
+let copyRows = new Set();
+
+//ids
+let tableID;
+let copyLinkID;
+let contextMenuID;
+let copyToastID;
+
+function addRightClickTable() {
+    //add special Right click on table menu
+    $(tableID).on('contextmenu', function (e) {
+        //initialize special menu location
+        var top = ((e.clientY / $(window).height()) * 100) + "%";
+        var left = ((e.clientX / $(window).width()) * 100) + "%";
+
+        //show special menu at the bottom right of the mouse
+        $(contextMenuID).css({
+            display: "block",
+            position: "fixed",
+            top: top,
+            left: left
+        }).addClass("show");
+
+        //get the row
+        let row = $(e.target).closest("tr")[0];
+
+        //if it's not selected and the control key wasn't pressed reset the selection
+        if (!row.classList.contains(selectionClass) && !e.ctrlKey) {
+            resetCopyRowSelection();
+
+            //if the shift key was pressed, select start index to recently clicked index
+            if (e.shiftKey) {
+                selectStartToCurrent(getRowArrayIndex(row));
+            }
+        }
+        //add current row to selection
+        addRowToSelection(row, e);
+
+        return false; //blocks default Webbrowser right click menu
+    });
+
+    //update selections
+    $(tableID).on('click', function (e) {
+        //hide the special menu and initialize variables
+        hideContextMenu();
+
+        //make sure it's only weapon rows being clicked
+        let row = $(e.target).closest("tr")[0];
+        if (!dragged) {
+            if (overARow(row)) {
+                //if it's a new selection set reset the selections
+                if (copyRows.size > 0 && !e.ctrlKey && !e.shiftKey) {
+                    resetCopyRowSelection(e);
+                }
+
+                //disable on-click selection for mobile
+                if (!isMobileScreen()) {
+                    //if the ctrl key was pressed while a selection was clicked remove it
+                    let rowIndex = getRowArrayIndex(row);
+                    if (e.ctrlKey && copyRows.has(row) && copyRows.size > 1) {
+                        deleteRowFromSelection(row);
+                    } else if (selectedRowIndex != undefined && e.shiftKey) {
+                        resetCopyRowSelection(e);
+                        selectSelectionToCurrent(rowIndex);
+                    } else if (e.ctrlKey) {
+                        if (copyRows.has(row)) {
+                            deleteRowFromSelection(row);
+                        } else {
+                            addRowToSelection(row, e);
+                        }
+                    } else {
+                        //otherwise just add the current row to selection
+                        if (isThereAMainSelection()) {
+                            startRowIndex = rowIndex;
+                        }
+                        selectedRowIndex = rowIndex;
+                        addRowToSelection(row);
+                    }
+                }
+            } else {
+                resetCopyRowSelection(e);
+            }
+        }
+    });
+
+    //add event listner for copy click
+    $(copyLinkID).on('click', function () {
+        $(copyToastID).toast('show');
+        hideContextMenu();
+    });
+
+    //add page click events
+    $(document).on("click", function (e) {
+        //if the click is not in the table remove selections and hide the special menu
+        if ($(e.target).closest("table")[0] == undefined && !dragged) {
+            resetCopyRowSelection(e);
+            hideContextMenu();
+        }
+    });
+
+    //add page key events
+    $(document).on("keyup", function (e) {
+        //if the user presses ctrl-C with something selected copy selected rows
+        if (e.key === 'c' && e.ctrlKey && copyRows.size > 0) {
+            copySelectedRows();
+            $(copyToastID).toast('show');
+        }
+    });
+
+    //add page right click events to hide special menu
+    $(document).on("contextmenu", function () {
+        hideContextMenu();
+    });
+
+    //hide the special menu when an option is clicked
+    $(contextMenuID).on("click", function () {
+        hideContextMenu();
+    });
+
+    //add copy clicks
+    addCopyClick();
+    addTableMove();
+}
+
+function resetCopyRowSelection(e) {
+    //remove the selection style from each row and reinit the set
+    copyRows.forEach(row => {
+        $(row).removeClass(selectionClass).removeClass(mainSelectionClass);
+    });
+    copyRows = new Set();
+    if (e == undefined || !e.shiftKey) {
+        selectedRowIndex = undefined;
+    }
+}
+
+function hideContextMenu() {
+    $(contextMenuID).removeClass("show").hide();
+}
+
+function addCopyClick() {
+    $(copyLinkID).on('click', copySelectedRows);
+}
+
+function addTableMove() {
+    $(tableID).on('mousedown', function (e) {
+        let row = $(e.target).closest("tr")[0];
+        if (overARow(row)) {
+            $(tableID).off('mousemove', tableMouseMoveEventHandler);
+            $(tableID).on('mousemove', tableMouseMoveEventHandler);
+        }
+        dragged = false;
+    });
+    $(document).on('mouseup', function (e) {
+        $(tableID).off('mousemove', tableMouseMoveEventHandler);
+
+        setTimeout(function () {
+            if (dragged) {
+                dragged = false;
+                selectedRowIndex = startRowIndex;
+            }
+        }, 10);
+    });
+}
+
+let prevDate = new Date().getTime();
+function tableMouseMoveEventHandler(e) {
+    var date = new Date().getTime();
+    if (date - prevDate > 2) {
+        let row = $(e.target).closest("tr")[0];
+        let rowIndex = getRowArrayIndex(row);
+        if (!dragged) {
+            startRowIndex = rowIndex;
+            if (!e.shiftKey && !e.ctrlKey) {
+                resetCopyRowSelection(e);
+            } else if (e.shiftKey && $('.' + selectionClass).length > 0) {
+                startRowIndex = selectedRowIndex;
+                resetCopyRowSelection();
+                selectStartToCurrent(rowIndex);
+                prevRowIndex = rowIndex;
+                upDown = isSelectionAboveStart(rowIndex);
+                if (upDown) {
+                    prevRowIndex++;
+                } else {
+                    prevRowIndex--;
+                }
+            }
+            currentRowIndex = rowIndex;
+        }
+        if (overARow(row)) {
+            toggleSelectionDrag(row);
+        }
+        prevDate = date;
+    }
+}
+
+function toggleSelectionDrag(row) {
+    let rowIndex = getRowArrayIndex(row);
+    //console.log(rowIndex + " " + startRowIndex + " " + selectedRowIndex + " " + currentRowIndex + " " + prevRowIndex);
+
+    if (isSelectionMoveValid(rowIndex)) {
+        if (!copyRows.has(row)) {
+            addRowToSelection(row);
+            upDown = (rowIndex <= startRowIndex);
+            prevRowIndex = currentRowIndex;
+        } else if (startRowIndex != currentRowIndex && rowIndex == prevRowIndex) {
+            deleteRowFromSelection(rowArray[currentRowIndex]);
+            if (upDown) {
+                prevRowIndex++;
+            } else {
+                prevRowIndex--;
+            }
+        }
+    } else {
+        resetCopyRowSelection();
+        selectStartToCurrent(rowIndex);
+        prevRowIndex = rowIndex;
+        upDown = isSelectionAboveStart(rowIndex);
+        if (upDown) {
+            prevRowIndex++;
+        } else {
+            prevRowIndex--;
+        }
+    }
+    if (rowIndex != startRowIndex) {
+        currentRowIndex = rowIndex;
+    } else {
+        if (prevRowIndex != startRowIndex) {
+            deleteRowFromSelection(rowArray[prevRowIndex]);
+        }
+        prevRowIndex = undefined;
+        currentRowIndex = startRowIndex;
+    }
+    selectedRowIndex = currentRowIndex;
+    dragged = true;
+}
+
+function selectStartToCurrent(rowIndex) {
+    if (isSelectionAboveStart(rowIndex)) {
+        for (let i = startRowIndex; i >= rowIndex; i--) {
+            addRowToSelection(rowArray[i]);
+        }
+    } else {
+        for (let i = startRowIndex; i <= rowIndex; i++) {
+            addRowToSelection(rowArray[i]);
+        }
+    }
+}
+
+function selectSelectionToCurrent(rowIndex) {
+    if (isSelectionAboveSelection(rowIndex)) {
+        for (let i = selectedRowIndex; i >= rowIndex; i--) {
+            addRowToSelection(rowArray[i]);
+        }
+    } else {
+        for (let i = selectedRowIndex; i <= rowIndex; i++) {
+            addRowToSelection(rowArray[i]);
+        }
+    }
+}
+
+function isSelectionAboveStart(rowIndex) {
+    return rowIndex < startRowIndex;
+}
+
+function isSelectionAboveSelection(rowIndex) {
+    return rowIndex < selectedRowIndex;
+}
+
+function isSelectionMoveValid(rowIndex) {
+    return currentRowIndex == rowIndex || rowIndex == currentRowIndex + 1 || rowIndex == currentRowIndex - 1;
+}
+
+function getRowArrayIndex(row) {
+    if (row != undefined) {
+        rowArray = [...$(tableID).find("tbody").first()[0].children];
+        return rowArray.findIndex(object => {
+            return object.id === row.id;
+        });
+    } else {
+        return undefined;
+    }
+}
+
+function deleteRowFromSelection(row) {
+    copyRows.delete(row);
+    $(row).removeClass(selectionClass).removeClass(mainSelectionClass);
+    let rowIndex = getRowArrayIndex(row);
+    if (!dragged && startRowIndex != rowIndex && rowIndex == selectedRowIndex) {
+        $('.' + selectionClass).removeClass(mainSelectionClass);
+    }
+    if (!isThereAMainSelection()) {
+        mainSelectClosestSelection(rowIndex);
+    }
+}
+
+function addRowToSelection(row, e) {
+    copyRows.add(row);
+    $(row).addClass(selectionClass);
+    let rowIndex = getRowArrayIndex(row);
+
+    if (isCtrlKeyPressedAndChangesStart(rowIndex, e)) {
+        startRowIndex = rowIndex;
+        selectedRowIndex = rowIndex;
+        $('.' + selectionClass).removeClass(mainSelectionClass);
+        $(row).add(mainSelectionClass);
+    } else if (startRowIndex == getRowArrayIndex(row)) {
+        $('.' + selectionClass).add(mainSelectionClass);
+    }
+    if (!isThereAMainSelection()) {
+        mainSelectClosestSelection(getRowArrayIndex(row));
+    }
+}
+
+function isThereAMainSelection() {
+    return $('.' + mainSelectionClass).length != 0;
+}
+
+function isCtrlKeyPressedAndChangesStart(rowIndex, e) {
+    return (copyRows.length > 1 && !dragged && e != undefined && e.ctrlKey && ((upDown && rowIndex > startRowIndex) || (!upDown && rowIndex < startRowIndex))) || (!dragged && e != undefined && e.ctrlKey);
+}
+
+function mainSelectClosestSelection(rowIndex) {
+    let i = rowIndex;
+    let iFound = false;
+    let j = rowIndex;
+    let jFound = false;
+    for (; i < rowArray.length; i++) {
+        if (rowArray[i].classList.contains(selectionClass)) {
+            iFound = true;
+            break;
+        }
+    }
+
+    for (; j >= 0; j--) {
+        if (rowArray[j].classList.contains(selectionClass)) {
+            jFound = true;
+            break;
+        }
+    }
+
+    if (iFound && jFound) {
+        if (Math.abs(i - rowIndex) >= Math.abs(j - rowIndex)) {
+            updateIndexVariablesAfterSwap(j);
+        } else {
+            updateIndexVariablesAfterSwap(i);
+        }
+    } else if (iFound && !jFound) {
+        updateIndexVariablesAfterSwap(i);
+    } else if (!iFound && jFound) {
+        updateIndexVariablesAfterSwap(j);
+    } else {
+        return;
+    }
+}
+
+function updateIndexVariablesAfterSwap(newIndex) {
+    $(rowArray[newIndex]).addClass(mainSelectionClass);
+    startRowIndex = newIndex;
+    selectedRowIndex = newIndex;
+}
+
+function isMobileScreen() {
+    return window.innerWidth <= 767;
+}
+
+function overARow(row) {
+    return row != undefined && row.localName == "tr" && row.parentElement.localName == "tbody";
+}
+
+function copySelectedRows(e) {
+    let copyString = "";
+    if (customCopyFunction != undefined) {
+        copyString = customCopyFunction();
+    } else {
+        let headerArray = [...$(tableID).find('thead').first().find('tr').first()[0].children];
+        let index = 0;
+        copyRows.forEach(row => {
+            let dataArray = $(row).find('td');
+            copyString = copyString + headerArray[0].innerText + ": " + dataArray[0].innerText;
+            for (let i = 1; i < dataArray.length; i++) {
+                copyString = copyString + ", " + headerArray[i].innerText + ": " + dataArray[i].innerText;
+            }
+            if (index < copyRows.size - 1) {
+                copyString = copyString + "\n\n";
+                index++;
+            }
+
+        });
+    }
+
+    //copy the new url to clipboard and reset selection
+    navigator.clipboard.writeText(copyString);
+    resetCopyRowSelection(e);
+}
+
+export function getSelectedRows() {
+    return copyRows;
+}
+
+export function setCustomCopyFunction(customFunction) {
+    customCopyFunction = customFunction;
+}
+
+export function init(id) {
+    tableID = '#' + id;
+    copyLinkID = tableID + "-copy-link";
+    contextMenuID = tableID + "-context-menu";
+    copyToastID = tableID + "-copy-toast";
+    rowArray = [...$(tableID).find("tbody").first()[0].children];
+
+    addRightClickTable();
+}

--- a/priv/static/js/flex-bootstrap-table-selection.js
+++ b/priv/static/js/flex-bootstrap-table-selection.js
@@ -58,7 +58,7 @@ function addRightClickTable() {
         //hide the special menu and initialize variables
         hideContextMenu();
 
-        //make sure it's only weapon rows being clicked
+        //make sure it's only tbody rows being clicked
         let row = $(e.target).closest("tr")[0];
         if (!dragged) {
             if (overARow(row)) {

--- a/priv/static/js/flex-bootstrap-table.js
+++ b/priv/static/js/flex-bootstrap-table.js
@@ -27,6 +27,7 @@ export function setupFlexTables() {
             addToolBarClick();
             addSearchEnter();
             addPaginationClick();
+            addOnDocumentMouseUp();
             showHideNextAuraxButton();
         });
     }
@@ -129,6 +130,21 @@ export function setupFlexTables() {
     function refreshByScroll() {
         window.scrollBy(0, -1);
         window.scrollBy(0, 1);
+    }
+
+    function documentMouseUpEventHandler() {
+        setTimeout(function () {
+            if (!didTableRecieveStyleUpdate()) {
+                addAnimationToProgressBars();
+                addFormatsToPage();
+                refreshByScroll();
+            }
+        }, 100);
+    }
+
+    function addOnDocumentMouseUp() {
+        $(document).off("mouseup", documentMouseUpEventHandler);
+        $(document).on("mouseup", documentMouseUpEventHandler);
     }
 
     let prevDate = new Date().getTime();

--- a/priv/static/js/flex-bootstrap-table.js
+++ b/priv/static/js/flex-bootstrap-table.js
@@ -40,16 +40,26 @@ export function setupFlexTables() {
 
     function tableSearchEnterEventHandler(e) {
         if (e.keyCode == 13) {
-            updateSearchParam();
+            searchTable(e);
+        } else {
+            let text = JSON.parse(JSON.stringify(document.querySelector("input.search-input").value));
             setTimeout(function () {
-                bootstrapTableFilter.updateTableFiltration();
-                updateTableFormats(table.id);
-            }, 10);
-
-            if (document.querySelector("input.search-input").value != "") {
-                if (window.innerWidth >= 768) {
-                    document.querySelector("input.search-input").select();
+                if (text == document.querySelector("input.search-input").value) {
+                    searchTable(e);
                 }
+            }, 300);
+        }
+    }
+    function searchTable(e) {
+        updateSearchParam();
+        setTimeout(function () {
+            bootstrapTableFilter.updateTableFiltration();
+            updateTableFormats(table.id);
+        }, 10);
+
+        if (document.querySelector("input.search-input").value != "" && e.keyCode == 13) {
+            if (window.innerWidth >= 768) {
+                document.querySelector("input.search-input").select();
             }
         }
     }

--- a/priv/static/js/flex-bootstrap-table.js
+++ b/priv/static/js/flex-bootstrap-table.js
@@ -149,6 +149,7 @@ export function setupFlexTables() {
     function documentMouseUpEventHandler() {
         setTimeout(function () {
             if (!didTableRecieveStyleUpdate()) {
+                setMobileHeaderTexts(table.id);
                 addAnimationToProgressBars();
                 addFormatsToPage();
                 refreshByScroll();

--- a/priv/static/js/flex-bootstrap-table.js
+++ b/priv/static/js/flex-bootstrap-table.js
@@ -10,7 +10,6 @@ export function setupFlexTables() {
     document.querySelectorAll('.table-responsive-stack').forEach(table => {
         bootstrapTableFilter.init(table.id);
         bootstrapSelection.init(table.id);
-        initializeStickyHeaderWidths();
         init();
     });
 
@@ -23,6 +22,7 @@ export function setupFlexTables() {
     function initializeFlexTables() {
         document.querySelectorAll('.table-responsive-stack').forEach(responseTable => {
             table = responseTable;
+            initializeStickyHeaderWidths();
             setMobileHeaderTexts(table.id);
             addOnTHeadClick();
             addToolBarClick();

--- a/priv/static/js/flex-bootstrap-table.js
+++ b/priv/static/js/flex-bootstrap-table.js
@@ -6,11 +6,11 @@ import * as bootstrapSelection from "/js/flex-bootstrap-table-selection.js";
 let table;
 
 export function setupFlexTables() {
-    init();
 
     document.querySelectorAll('.table-responsive-stack').forEach(table => {
         bootstrapTableFilter.init(table.id);
         bootstrapSelection.init(table.id);
+        init();
     });
 
     function init() {
@@ -34,7 +34,7 @@ export function setupFlexTables() {
     function setNextAuraxVisibilities() {
         setTimeout(function () {
             showHideNextAuraxButton();
-        }, 500);
+        }, 10);
     }
 
     function tableSearchEnterEventHandler(e) {
@@ -43,7 +43,7 @@ export function setupFlexTables() {
             setTimeout(function () {
                 bootstrapTableFilter.updateTableFiltration();
                 updateTableFormats(table.id);
-            }, 500);
+            }, 10);
 
             if (document.querySelector("input.search-input").value != "") {
                 if (window.innerWidth >= 768) {
@@ -183,19 +183,19 @@ export function setupFlexTables() {
                 //otherwise reinitialize the table
                 init();
             }
-        }, 500);
+        }, 10);
     }
 
     function tablePaginationClickEventHandler(e) {
-        if (e.target.classList.contains("page-link") || e.target.classList.contains("dropdown-item")) {
-            setTimeout(function () {
-                updateTableFormats(table.id);
-            }, 500);
-        }
+        setTimeout(function () {
+            updateTableFormats(table.id);
+        }, 10);
     }
     function addPaginationClick() {
-        $('a').off('click', tablePaginationClickEventHandler);
-        $('a').on('click', tablePaginationClickEventHandler);
+        $('a.page-link').off('click', tablePaginationClickEventHandler);
+        $('a.dropdown-item').off('click', tablePaginationClickEventHandler);
+        $('a.page-link').on('click', tablePaginationClickEventHandler);
+        $('a.dropdown-item').on('click', tablePaginationClickEventHandler);
     }
 }
 

--- a/priv/static/js/flex-bootstrap-table.js
+++ b/priv/static/js/flex-bootstrap-table.js
@@ -10,9 +10,9 @@ export function setupFlexTables() {
     document.querySelectorAll('.table-responsive-stack').forEach(table => {
         bootstrapTableFilter.init(table.id);
         bootstrapSelection.init(table.id);
+        initializeStickyHeaderWidths();
         init();
     });
-    initializeStickyHeaderWidths();
 
     function init() {
         initializeFlexTables();

--- a/priv/static/js/flex-bootstrap-table.js
+++ b/priv/static/js/flex-bootstrap-table.js
@@ -102,6 +102,10 @@ export function setupFlexTables() {
         setTimeout(function () {
             setFlexTableVisibilities();
         }, 10);
+
+        setTimeout(function () {
+            setMobileHeaderTexts(table.id);
+        }, 500);
     }
     function dropDownMenuClickEventHandler(e) {
         let target = e.target;
@@ -236,7 +240,9 @@ export function updateSearchParam() {
 export function setMobileHeaderTexts(tableID) {
     //append each header text to the front of the corresponding data element and hide it
     $('#' + tableID).find("th").each(function (i) {
-        $('#' + tableID + ' td:nth-child(' + (i + 1) + ')').prepend(getMobileHeader(hasMobileHeader($('#' + tableID + ' td:nth-child(' + (i + 1) + ')').html()) ? "" : getMobileHeader($(this).text())));
+        let tds = '#' + tableID + ' td:nth-child(' + (i + 1) + ')';
+        $(tds).prepend(getMobileHeader(hasMobileHeader($(tds).html()) ? ""
+            : getMobileHeader((document.querySelector(tds).hasAttribute('data-mobile-title')) ? document.querySelector(tds).getAttribute('data-mobile-title') : $(this).text())));
         if (window.innerWidth > 767) {
             $('.table-responsive-stack-thead').hide();
         }

--- a/priv/static/js/flex-bootstrap-table.js
+++ b/priv/static/js/flex-bootstrap-table.js
@@ -1,6 +1,7 @@
 import { addFormatsToPage, addAnimationToProgressBars } from "/js/formats.js";
 import { showHideNextAuraxButton } from "/js/character/weapons-table.js";
 import * as bootstrapTableFilter from "/js/flex-bootstrap-table-filter.js";
+import * as bootstrapSelection from "/js/flex-bootstrap-table-selection.js";
 
 let table;
 
@@ -9,6 +10,7 @@ export function setupFlexTables() {
 
     document.querySelectorAll('.table-responsive-stack').forEach(table => {
         bootstrapTableFilter.init(table.id);
+        bootstrapSelection.init(table.id);
     });
 
     function init() {

--- a/priv/static/js/flex-bootstrap-table.js
+++ b/priv/static/js/flex-bootstrap-table.js
@@ -12,7 +12,7 @@ export function setupFlexTables() {
         bootstrapSelection.init(table.id);
         init();
     });
-    refreshByScroll(); //fixes sticky header being in the wrong position on start
+    initializeStickyHeaderWidths();
 
     function init() {
         initializeFlexTables();
@@ -155,7 +155,7 @@ export function setupFlexTables() {
                 addFormatsToPage();
 
                 setTimeout(function () {
-                    bootstrapTableFilter.setStickyHeaderWidths();
+                    setStickyHeaderWidths();
                 }, 100);
             }
         }, 100);
@@ -204,7 +204,7 @@ export function setupFlexTables() {
         setNextAuraxVisibilities();
         bootstrapTableFilter.showHideClearFilterButtons();
         makeSureTableRecievedStyles();
-        bootstrapTableFilter.setStickyHeaderWidths();
+        setStickyHeaderWidths();
     }
 
     function makeSureTableRecievedStyles(tableID) {
@@ -294,6 +294,32 @@ export function didTableRecieveStyleUpdate() {
         }
     }
     return true;
+}
+
+function initializeStickyHeaderWidths() {
+    //get the current scroll position and scroll to the top of the page
+    let top = JSON.parse(JSON.stringify(document.body.scrollTop));
+    document.body.scrollTop = 0;
+
+    //set the sticky header widths
+    setStickyHeaderWidths();
+
+    //reset the scroll position to the original
+    document.body.scrollTop = top;
+}
+
+export function setStickyHeaderWidths() {
+    //initialize variables
+    let headers = document.querySelector("thead.sticky-header > tr").querySelectorAll("th");
+    let columns = document.querySelector("#" + table.id + ">tbody>tr").querySelectorAll("td");
+
+    //make sure each header matches it's matching td
+    for (let i = 0; i < headers.length; i++) {
+        let width = $(columns[i]).width();
+        $(headers[i]).css({
+            'width': width + 'px'
+        });
+    }
 }
 
 export function setFlexTableVisibilities() {

--- a/priv/static/js/flex-bootstrap-table.js
+++ b/priv/static/js/flex-bootstrap-table.js
@@ -12,6 +12,7 @@ export function setupFlexTables() {
         bootstrapSelection.init(table.id);
         init();
     });
+    refreshByScroll(); //fixes sticky header being in the wrong position on start
 
     function init() {
         initializeFlexTables();
@@ -155,7 +156,6 @@ export function setupFlexTables() {
 
                 setTimeout(function () {
                     bootstrapTableFilter.setStickyHeaderWidths();
-                    refreshByScroll();
                 }, 100);
             }
         }, 100);

--- a/priv/static/js/flex-bootstrap-table.js
+++ b/priv/static/js/flex-bootstrap-table.js
@@ -59,7 +59,7 @@ export function setupFlexTables() {
         }
     }
     function addSearchEnter() {
-        document.querySelectorAll('.search-input').forEach(searchInput => {
+        document.querySelectorAll('input.search-input').forEach(searchInput => {
             searchInput.removeEventListener('keydown', tableSearchEnterDownEventHandler);
             searchInput.addEventListener('keydown', tableSearchEnterDownEventHandler);
             searchInput.removeEventListener('keyup', tableSearchEnterEventHandler);
@@ -183,7 +183,9 @@ export function setupFlexTables() {
         }
         setMobileHeaderTexts(tableID);
         setNextAuraxVisibilities();
+        bootstrapTableFilter.showHideClearFilterButtons();
         makeSureTableRecievedStyles();
+        bootstrapTableFilter.setStickyHeaderWidths();
     }
 
     function makeSureTableRecievedStyles(tableID) {

--- a/priv/static/js/flex-bootstrap-table.js
+++ b/priv/static/js/flex-bootstrap-table.js
@@ -152,7 +152,11 @@ export function setupFlexTables() {
                 setMobileHeaderTexts(table.id);
                 addAnimationToProgressBars();
                 addFormatsToPage();
-                refreshByScroll();
+
+                setTimeout(function () {
+                    bootstrapTableFilter.setStickyHeaderWidths();
+                    refreshByScroll();
+                }, 100);
             }
         }, 100);
     }

--- a/priv/static/js/formats.js
+++ b/priv/static/js/formats.js
@@ -59,7 +59,9 @@ export function addFormatsToPage() {
         const MINUTE_SECOND = 60;
 
         seconds.forEach(second => {
-            let secondCount = +second.innerHTML;
+            let secondFindingArray = second.innerHTML.split("</span>");
+            let secondCount = +secondFindingArray[secondFindingArray.length - 1];
+
             //if it's a number
             if (!isNaN(secondCount)) {
                 let time = "";


### PR DESCRIPTION
Okay, so it turns out a lot of our issues with firefox were not actually on our work, but on the bootstrap add-on that we were using. I was able to just manipulate the styles after the add-on did to get it fixed. (Honestly, I thought about removing the add-on "Sticky-Header", but it still did do a lot that I wasn't up to replacing yet.) It's just strange that it works fine in Chrome. 

I ended up pulling a lot of the styling out of `weapons.css` into its own separate CSS pages as they were more specific to the table than specifically the weapons table. (this will basically be nicer for later)

I made selecting a lot more user-friendly to be able to select any weapon row you want. For the desktop view, I made the selecting rules/ shortcut keys like how google sheets does it. (this includes drag, shift, and ctrl-clicking) For the mobile view, I tried to make it feel more like how it does (on android at least) in the gallery when you try to select photos to edit, delete, etc. 

I added some more understandable mobile header wordings as well. This will make it a bit easier to tell what the data actually means since mobile doesn't have a hover tooltip to help them out. (Ex. VW: Yes => Vehicle Weapon: Yes)

I also added some darker backgrounds to the weapon column data (a radial black gradient behind the medal and a gray background to the progress bar).

The last thing I did was add an auto search that will trigger a search after something is typed (can also be a backspace keystroke) and no other key was pressed within 300 milliseconds. This will allow the user to still type without a jarring auto-search, but not be sitting there waiting for something to happen and not realize they need to hit enter. I felt like it was more user-friendly to go down this route, and the enter key can also be used to instantly search (if 300 milliseconds is too long to wait lol). When I added this functionality though I realized that since I created our own filtration, it was searching twice and I couldn't stop it. The double search would bring up the wrong data, so I just ended up removing the add-on search and created our own.

You mentioned before about when dragging a column the table would kind of jump a bit, but there is nothing I can really do with that other than rewrite the dragging add-on which would be really intense. The only fix I can think of doing to patch it is to only allow the user to drag columns when it's in the upper left most scroll position as it only happens due to the table being in an overflow scroll. But I'm not sure if that's possible either.  Let me know if you find any more issues though.

This will close #54.