### PR TITLE
Weapon Table Clean up

### DIFF
--- a/priv/static/css/bootstrap-override.css
+++ b/priv/static/css/bootstrap-override.css
@@ -5220,7 +5220,7 @@ tbody.collapse.show {
 }
 
 .page-item.active .page-link {
-  z-index: 1;
+  z-index: 0;
   color: #fff;
   background-color: #9B84EE;
   border-color: #9B84EE;

--- a/priv/static/js/character/weapons-table.js
+++ b/priv/static/js/character/weapons-table.js
@@ -4,7 +4,9 @@ import * as bootstrapSelection from "/js/flex-bootstrap-table-selection.js";
 
 window.addEventListener('load', (event) => {
     if (window.innerWidth >= 768) {
-        $("input.search-input:first").focus();
+        setTimeout(function () {
+            $("input.search-input:first").focus();
+        }, 100);
     }
 
     //TODO edit dataset based on cached persistent data

--- a/priv/static/js/flex-bootstrap-table-column.js
+++ b/priv/static/js/flex-bootstrap-table-column.js
@@ -1,0 +1,145 @@
+let tableID;
+let table;
+let globalIndexOrder;
+let globalColumns;
+
+window.addEventListener('load', (event) => {
+    fixColumnDropDown();
+});
+
+export function fixColumnDropDown() {
+    //fix column dropdown offset and bugs
+    let columnDropDown = document.querySelector("button[title='Columns']");
+    columnDropDown.parentElement.lastChild.style.width = "20rem";
+
+    columnDropDown.click();
+    columnDropDown.click();
+}
+
+function getSortedField() {
+    let toSortDesc = table.querySelector(".desc");
+    let toSortAsc = table.querySelector(".asc");
+
+    let sortedFieldText;
+    let order;
+    if (toSortDesc != undefined) {
+        sortedFieldText = toSortDesc.innerText;
+        order = "desc";
+    } else if (toSortAsc != undefined) {
+        sortedFieldText = toSortAsc.innerText;
+        order = "asc";
+    }
+
+    return { "sortedFieldText": sortedFieldText, "order": order };
+}
+
+function setSortedField(sortedFieldText, sortTo) {
+    if (sortedFieldText != undefined) {
+        let el = Array.from(table.querySelectorAll('div.th-inner')).find(el => el.textContent === sortedFieldText);
+
+        el.click();
+        if (![...el.classList].includes(sortTo)) {
+            el.click();
+        }
+        refreshByScroll();
+    }
+}
+
+function refreshByScroll() {
+    window.scrollBy(0, -1);
+    window.scrollBy(0, 1);
+}
+
+function findVisibleFields() {
+    var columns = $(tableID).bootstrapTable('getVisibleColumns');
+    var fields = [];
+
+    for (var index in columns) {
+        fields.push({
+            "field": columns[index].field,
+            "title": columns[index].title
+        });
+    }
+    return fields;
+}
+
+function findSortedVisibleFields() {
+    let fields = findVisibleFields();
+    let tempFields = [];
+    table.querySelectorAll('div.th-inner').forEach(header => {
+        for (let i = 0; i < fields.length; i++) {
+            if (fields[i].title == header.innerText) {
+                tempFields.push(fields[i]);
+                break;
+            }
+        }
+    });
+    console.log(tempFields);
+    return tempFields;
+}
+
+function initializeColumns() {
+    //initialize variables
+    let persistentColumnsName = table.id + "/columnMap";
+    let persistentColumns = localStorage.getItem(persistentColumnsName);
+
+    //if there are persistent columns, initialize new columns
+    if (persistentColumns != undefined) {
+        setColumnVisibilitesAndSorts(JSON.parse(persistentColumns));
+    }
+}
+
+function setColumnVisibilitesAndSorts(persistentColumns) {
+    $(tableID).bootstrapTable('hideAllColumns');
+
+    let indexOrder = [];
+    persistentColumns["fields"].forEach(field => {
+        let index = persistentColumns["fields"].findIndex(object => {
+            return object["field"] === field["field"];
+        });
+        indexOrder.push(index);
+    });
+
+    globalIndexOrder = indexOrder;
+    globalColumns = persistentColumns;
+
+    setColumnOrder();
+    setSortedField(persistentColumns["sorted"]["sortedFieldText"], persistentColumns["sorted"]["order"]);
+}
+
+function setColumnOrder() {
+    let orderObject = {};
+    let array = []
+    for (let i = 0; i < globalIndexOrder.length; i++) {
+        let object = {};
+        object["index"] = globalIndexOrder[i];
+        object["field"] = globalColumns["fields"][i]["field"]
+        array.push(object);
+        orderObject[globalColumns["fields"][i]["field"]] = globalIndexOrder[i];
+    }
+
+    for (let i = 0; i < array.length; i++) {
+        let fieldIndex = array.findIndex(object => {
+            return object["index"] == i;
+        });
+        $(tableID).bootstrapTable('showColumn', array[fieldIndex]["field"]);
+    }
+    //$(tableID).bootstrapTable('orderColumns', orderObject); DOESN'T WORK FOR DATA ONLY HEADERS
+}
+
+export function updateColumns() {
+    let persistentColumnsName = table.id + "/columnMap";
+    localStorage.removeItem(persistentColumnsName);
+
+    let fields = findSortedVisibleFields();
+    let sorted = getSortedField();
+    localStorage.setItem(persistentColumnsName, JSON.stringify({ "fields": fields, "sorted": sorted }));
+}
+
+export function init(id) {
+    //initialize class variables
+    tableID = '#' + id;
+    table = document.getElementById(id);
+
+    initializeColumns();
+}

--- a/priv/static/js/flex-bootstrap-table-column.js
+++ b/priv/static/js/flex-bootstrap-table-column.js
@@ -74,7 +74,7 @@ function findSortedVisibleFields() {
             }
         }
     });
-    console.log(tempFields);
+
     return tempFields;
 }
 

--- a/priv/static/js/flex-bootstrap-table-selection.js
+++ b/priv/static/js/flex-bootstrap-table-selection.js
@@ -27,44 +27,48 @@ function addRightClickTable() {
     //add special Right click on table menu
     $(tableID).on('contextmenu', function (e) {
         //get the row
-        let row = $(e.target).closest("tr")[0];
+        if (!document.querySelector("thead.sticky-header").contains(e.target)) {
+            let row = $(e.target).closest("tr")[0];
 
-        if (!isMobileScreen()) {
-            //initialize special menu location
-            let isFireFox = navigator.userAgent.indexOf("Firefox") != -1;
-            let yAdj = (e.clientY + $(contextMenuID).height() > $(window).height()) ? (e.clientY - $(contextMenuID).height() - (isFireFox ? 0 : 5)) : e.clientY; //adjust height to show all of menu
-            let xAdj = (e.clientX + $(contextMenuID).width() > $(window).width()) ? (e.clientX - $(contextMenuID).width() - (isFireFox ? 0 : 2)) : e.clientX; //adjust width to show all of menu
-            var top = ((yAdj / $(window).height()) * 100) + "%";
-            var left = ((xAdj / $(window).width()) * 100) + "%";
+            if (!isMobileScreen()) {
+                //initialize special menu location
+                let isFireFox = navigator.userAgent.indexOf("Firefox") != -1;
+                let yAdj = (e.clientY + $(contextMenuID).height() > $(window).height()) ? (e.clientY - $(contextMenuID).height() - (isFireFox ? 0 : 5)) : e.clientY; //adjust height to show all of menu
+                let xAdj = (e.clientX + $(contextMenuID).width() > $(window).width()) ? (e.clientX - $(contextMenuID).width() - (isFireFox ? 0 : 2)) : e.clientX; //adjust width to show all of menu
+                var top = ((yAdj / $(window).height()) * 100) + "%";
+                var left = ((xAdj / $(window).width()) * 100) + "%";
 
-            //show special menu at the bottom right of the mouse
-            $(contextMenuID).css({
-                display: "block",
-                position: "fixed",
-                top: top,
-                left: left
-            }).addClass("show");
+                //show special menu at the bottom right of the mouse
+                $(contextMenuID).css({
+                    display: "block",
+                    position: "fixed",
+                    top: top,
+                    left: left
+                }).addClass("show");
 
-            //if it's not selected and the control key wasn't pressed reset the selection
-            if (!row.classList.contains(selectionClass) && !e.ctrlKey) {
-                resetCopyRowSelection();
+                //if it's not selected and the control key wasn't pressed reset the selection
+                if (!row.classList.contains(selectionClass) && !e.ctrlKey) {
+                    resetCopyRowSelection();
 
-                //if the shift key was pressed, select start index to recently clicked index
-                if (e.shiftKey) {
-                    selectStartToCurrent(getRowArrayIndex(row));
+                    //if the shift key was pressed, select start index to recently clicked index
+                    if (e.shiftKey) {
+                        selectStartToCurrent(getRowArrayIndex(row));
+                    }
                 }
+
+                //if it's a mobile screen and the row is already selected, delete it and return false to block default right click menu
+            } else if (copyRows.has(row)) {
+                deleteRowFromSelection(row);
+                return false;
             }
 
-            //if it's a mobile screen and the row is already selected, delete it and return false to block default right click menu
-        } else if (copyRows.has(row)) {
-            deleteRowFromSelection(row);
-            return false;
+            //add current row to selection
+            addRowToSelection(row, e);
+
+            return false; //blocks default Webbrowser right click menu
+        } else {
+            return;
         }
-
-        //add current row to selection
-        addRowToSelection(row, e);
-
-        return false; //blocks default Webbrowser right click menu
     });
 
     //update selections

--- a/priv/static/js/flex-bootstrap-table.js
+++ b/priv/static/js/flex-bootstrap-table.js
@@ -2,6 +2,7 @@ import { addFormatsToPage, addAnimationToProgressBars } from "/js/formats.js";
 import { showHideNextAuraxButton } from "/js/character/weapons-table.js";
 import * as bootstrapTableFilter from "/js/flex-bootstrap-table-filter.js";
 import * as bootstrapSelection from "/js/flex-bootstrap-table-selection.js";
+import * as bootstrapColumn from "/js/flex-bootstrap-table-column.js";
 
 let table;
 
@@ -10,6 +11,7 @@ export function setupFlexTables() {
     document.querySelectorAll('.table-responsive-stack').forEach(table => {
         bootstrapTableFilter.init(table.id);
         bootstrapSelection.init(table.id);
+        bootstrapColumn.init(table.id);
         init();
     });
 
@@ -147,7 +149,7 @@ export function setupFlexTables() {
         window.scrollBy(0, 1);
     }
 
-    function documentMouseUpEventHandler() {
+    function documentMouseUpEventHandler(e) {
         setTimeout(function () {
             if (!didTableRecieveStyleUpdate()) {
                 setMobileHeaderTexts(table.id);
@@ -156,8 +158,20 @@ export function setupFlexTables() {
 
                 setTimeout(function () {
                     setStickyHeaderWidths();
+
+                    let clickInDropdownMenu = false;
+                    document.querySelectorAll("div.dropdown-menu").forEach(menu => {
+                        if (menu.contains(e.target)) {
+                            clickInDropdownMenu = true;
+                        }
+                    });
+
+                    if (!clickInDropdownMenu) {
+                        bootstrapColumn.fixColumnDropDown();
+                    }
                 }, 100);
             }
+            bootstrapColumn.updateColumns();
         }, 100);
     }
 


### PR DESCRIPTION
When I originally created the branch I was aiming to just get persistent columns, but I later thought a full clean-up would be good.

I fixed some stying errors.

I added persistent columns, but the catch is that I wasn't able to get the column orders to persist. The whole reason I decided to add persistent columns into `0.0.1` was that I thought it could be annoying that every time you use our site you would have to change it to how you like it (even for every time you swap characters). I tried getting the column orders to stick, but the package that we use, BootstrapTable, has a method `$(tableID).bootstrapTable('orderColumns', orderObject);` that is supposed to order them right, but it only orders the headers and not the data, so I just left that out entirely. 

This will close #91 