### PR TITLE
Fully hiding "Copied!" toast

### DIFF
--- a/lib/sacastats_web/templates/character/weapons.html.heex
+++ b/lib/sacastats_web/templates/character/weapons.html.heex
@@ -62,7 +62,7 @@
         </div>
     </div>
 </div>
-<div id="table-copy-toast" class="pb-0 toast" data-delay="600">
+<div id="table-copy-toast" class="pb-0 toast d-none" data-delay="600">
     <div class="toast-body text-center">
         <h5 class="pt-2">Copied!</h5>
     </div>

--- a/priv/static/js/flex-bootstrap-table-selection.js
+++ b/priv/static/js/flex-bootstrap-table-selection.js
@@ -566,7 +566,11 @@ function overARow(row) {
 }
 
 function copySelectedRows(e) {
+    $(copyToastID).removeClass("d-none");
     $(copyToastID).toast('show');
+    setTimeout(function () {
+        $(copyToastID).addClass("d-none");
+    }, 1000);
     hideContextMenu();
     let copyString = "";
     if (customCopyFunction != undefined || secondCustomCopyFunction != undefined) {


### PR DESCRIPTION
Fixed "Copied!" toast being over everything at all times.

This will close #99 