### PR TITLE
Revert sessions to use cookies instead of ETS

### DIFF
--- a/lib/sacastats/application.ex
+++ b/lib/sacastats/application.ex
@@ -15,9 +15,6 @@ defmodule SacaStats.Application do
       service_id: SacaStats.sid()
     ]
 
-    # Start session ETS table.
-    :ets.new(:session, [:named_table, :public, read_concurrency: true])
-
     children = [
       # Start the Ecto repository
       SacaStats.Repo,

--- a/lib/sacastats_web/endpoint.ex
+++ b/lib/sacastats_web/endpoint.ex
@@ -1,11 +1,13 @@
 defmodule SacaStatsWeb.Endpoint do
   use Phoenix.Endpoint, otp_app: :sacastats
 
-  # The session will be stored server side in an ETS table.
+  # The session will be stored in the cookie and signed,
+  # this means its contents can be read but not tampered with.
+  # Set :encryption_salt if you would also like to encrypt it.
   @session_options [
-    store: :ets,
-    key: "sid",
-    table: :session
+    store: :cookie,
+    key: "_sacastats_key",
+    signing_salt: "cl4MUJRp"
   ]
 
   socket "/live", Phoenix.LiveView.Socket, websocket: [connect_info: [session: @session_options]]


### PR DESCRIPTION
Main benefit to this: Users will stay logged in via Discord when we restart the prod app (e.g. deploying updates)