### PR TITLE
Update Poll Copy Link Text

### DIFF
--- a/lib/sacastats_web/live/poll_live/create.ex
+++ b/lib/sacastats_web/live/poll_live/create.ex
@@ -126,7 +126,7 @@ defmodule SacaStatsWeb.PollLive.Create do
          socket
          |> put_flash(
            :info,
-           "Success! You can share this poll with others by sharing this link: sacastats.com#{poll_path}"
+           "Success! You can share this poll with others by sharing this link: https://www.sacastats.com#{poll_path}"
          )
          |> redirect(to: poll_path)}
 


### PR DESCRIPTION
Added `https://www.` to the copy poll link to make it an active link that works properly.

This will close #108 