### PR TITLE
Fix dateTime formatter

### DIFF
--- a/priv/static/js/formats.js
+++ b/priv/static/js/formats.js
@@ -1,4 +1,5 @@
-const preferedLanguage = navigator.language;
+const PREFERED_LANGUAGE = navigator.languages ? navigator.languages[0] : (navigator.language || navigator.userLanguage);
+const PREFERED_TIME_ZONE = Intl.DateTimeFormat().resolvedOptions().timeZone;
 
 export function addFormatsToPage() {
     addCommasToNumbers();
@@ -21,14 +22,27 @@ export function addFormatsToPage() {
             let date = dateTimeString.split(" ")[0];
             let time = dateTimeString.split(" ")[1];
             if (!isNaN(date.charAt(0))) {
-                let dateTimeObject = new Date(getLocalDateStringWithTimeFromStrings(date, time));
-                const longFormatter = new Intl.DateTimeFormat(preferedLanguage, {
-                    year: 'numeric',
-                    month: 'long',
-                    day: 'numeric',
-                });
+                try {
+                    let dateTimeObject = new Date(getLocalDateStringWithTimeFromStrings(date, time));
+                    const LONG_FORMATTER = new Intl.DateTimeFormat(PREFERED_LANGUAGE, {
+                        year: 'numeric',
+                        month: 'long',
+                        day: 'numeric'
+                    });
 
-                dateTime.innerHTML = longFormatter.format(dateTimeObject) + " @ " + dateTimeObject.toLocaleTimeString();
+                    try {
+                        dateTime.innerHTML = LONG_FORMATTER.format(dateTimeObject) + " @ " + dateTimeObject.toLocaleTimeString(PREFERED_LANGUAGE);
+                    } catch (error) {
+                        console.error(error);
+                        console.error("LONG_FORMATTER: ");
+                        console.error(LONG_FORMATTER);
+                        console.error("dateTimeObject: ");
+                        console.error(dateTimeObject);
+                    }
+                } catch (error) {
+                    console.error(error);
+                    console.error("Time variables not defined for: '" + dateTimeString + "'.");
+                }
             }
         });
     }
@@ -37,7 +51,7 @@ export function addFormatsToPage() {
         let dateArr = date.split("-");
         let timeArr = time.split(":");
 
-        return new Date(Date.UTC(dateArr[0], dateArr[1] - 1, dateArr[2], timeArr[0], timeArr[1], timeArr[2].split(".")[0])).toLocaleString(preferedLanguage, { timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone });
+        return new Date(Date.UTC(dateArr[0], dateArr[1] - 1, dateArr[2], timeArr[0], timeArr[1], timeArr[2].split(".")[0])).toLocaleString('en-US', { timeZone: PREFERED_TIME_ZONE });
     }
 
     function addPercents() {


### PR DESCRIPTION
Fixed Non-US dates erroring out. This error was getting caused by the `dd-mm-yyyy` vs `mm-dd-yyyy` because `new Date()` was receiving `dd-mm-yyyy` and expecting `mm-dd-yyyy`.

I also added in some try catches to make sure that it's easier to debug as well as actually loading the page even if it doesn't work.

This will close #111 