### PR TITLE
Mobile nav background fix

### DIFF
--- a/assets/css/character/template.css
+++ b/assets/css/character/template.css
@@ -2,12 +2,15 @@
 .navbar-nav.character-nav {
     padding: 0px;
 }
-.character-nav > li.nav-item > a.nav-link{
+
+.character-nav>li.nav-item>a.nav-link {
     padding-bottom: 0px;
 }
-.character-nav{
+
+.character-nav {
     padding-bottom: 0px;
 }
+
 .pb-10 {
     padding-bottom: 10rem !important;
 }

--- a/lib/sacastats_web/templates/character/template.html.heex
+++ b/lib/sacastats_web/templates/character/template.html.heex
@@ -60,7 +60,7 @@
   <% end %>
 </main>
 <footer>
-  <nav class="navbar navbar-expand-md navbar-light bg-light d-md-none fixed-bottom top-bottom-nav pb-10">
+  <nav class="navbar navbar-expand-md navbar-light bg-light d-md-none fixed-bottom top-bottom-nav mb-7">
     <div class="bottom-navbar collapse navbar-collapse collapse_bottom_subnav_target" id="collapse_character_nav_bottom_target">
       <ul class="navbar-nav">
         <li class="nav-item subpage-nav">
@@ -74,7 +74,7 @@
         </li>
       </ul>
     </div>
-      <h1><%= @character_info["name"]["first"] %></h1>
+      <h1 class="mb-0"><%= @character_info["name"]["first"] %></h1>
     <button class="navbar-toggler collapsed" data-toggle="collapse" data-target="#collapse_character_nav_bottom_target">
       <span class="navbar-toggler-icon"></span>
     </button>

--- a/lib/sacastats_web/templates/character/template.html.heex
+++ b/lib/sacastats_web/templates/character/template.html.heex
@@ -60,7 +60,7 @@
   <% end %>
 </main>
 <footer>
-  <nav class="navbar navbar-expand-md navbar-light bg-light d-md-none fixed-bottom top-bottom-nav mb-7">
+  <nav class="navbar navbar-expand-md navbar-light bg-light d-md-none fixed-bottom top-bottom-nav pb-7">
     <div class="bottom-navbar collapse navbar-collapse collapse_bottom_subnav_target" id="collapse_character_nav_bottom_target">
       <ul class="navbar-nav">
         <li class="nav-item subpage-nav">

--- a/priv/static/css/character/template.css
+++ b/priv/static/css/character/template.css
@@ -11,10 +11,6 @@
     padding-bottom: 0px;
 }
 
-.pb-10 {
-    padding-bottom: 7rem !important;
-}
-
 @media only screen and (max-width: 767px) {
 
     /*for boostrap xs*/

--- a/priv/static/css/flex-bootstrap-table-selection.css
+++ b/priv/static/css/flex-bootstrap-table-selection.css
@@ -80,7 +80,7 @@ tbody tr.selection.main-selected>td {
 }
 
 .selection-mobile-menu-bottom {
-    bottom: 138px;
+    bottom: 128px;
 }
 
 #table-copy-toast {

--- a/priv/static/css/index.css
+++ b/priv/static/css/index.css
@@ -1,7 +1,3 @@
-nav {
-    background-color: #fff;
-}
-
 @media screen and (max-width: 767px) {
     #model-image {
         height: 300px;

--- a/priv/static/css/navbar-events.css
+++ b/priv/static/css/navbar-events.css
@@ -38,7 +38,7 @@ nav {
 }
 
 .top-bottom-nav {
-    transition: .4s;
+    transition: .3s;
 }
 
 .sticky-top {
@@ -95,11 +95,11 @@ ul.navbar-nav li:hover:nth-child(4n+4)>a {
     color: #716857 !important;
 }
 
-/*Margins*/
-.mb-27 {
-    margin-bottom: 27rem !important;
+/*Padding*/
+.pb-27 {
+    padding-bottom: 27rem !important;
 }
 
-.mb-7 {
-    margin-bottom: 7.5rem !important;
+.pb-7 {
+    padding-bottom: 7.5rem !important;
 }

--- a/priv/static/css/navbar-events.css
+++ b/priv/static/css/navbar-events.css
@@ -29,6 +29,7 @@
 
 nav {
     opacity: 0.94;
+    background-color: #f8f9fa;
 }
 
 .navbar-expand-md .navbar-collapse {
@@ -37,7 +38,7 @@ nav {
 }
 
 .top-bottom-nav {
-    transition: .3s;
+    transition: .4s;
 }
 
 .sticky-top {
@@ -94,8 +95,11 @@ ul.navbar-nav li:hover:nth-child(4n+4)>a {
     color: #716857 !important;
 }
 
-/*Padding*/
-.pb-26 {
-    padding-bottom: 24rem !important;
-    /*padding-bottom: 26rem !important; Will need to be this when we have more main navigation.*/
+/*Margins*/
+.mb-27 {
+    margin-bottom: 27rem !important;
+}
+
+.mb-7 {
+    margin-bottom: 7.5rem !important;
 }

--- a/priv/static/js/navbar-events.js
+++ b/priv/static/js/navbar-events.js
@@ -17,8 +17,8 @@ export function addNavbarEventListeners() {
 
     function initializeVariables() {
         bottomNavbars = document.querySelectorAll(".bottom-navbar");
-        oldPadding = "pb-10";
-        newPadding = "pb-26";
+        oldPadding = "mb-7";
+        newPadding = "mb-27";
         isBottomTopNavbarShown = false;
         isBottomBottomNavbarShown = false;
     }

--- a/priv/static/js/navbar-events.js
+++ b/priv/static/js/navbar-events.js
@@ -17,8 +17,8 @@ export function addNavbarEventListeners() {
 
     function initializeVariables() {
         bottomNavbars = document.querySelectorAll(".bottom-navbar");
-        oldPadding = "mb-7";
-        newPadding = "mb-27";
+        oldPadding = "pb-7";
+        newPadding = "pb-27";
         isBottomTopNavbarShown = false;
         isBottomBottomNavbarShown = false;
     }


### PR DESCRIPTION
Fixed main mobile nav background. To do this it needed to be margins instead of padding, but that means that if you press open on the sub-menu when the main menu is up, there is no background for part of in between the two menus that can't be covered without a lot of very precise padding changes on top of all of that.

This will close #113 