### PR TITLE
CensusCache entry expiration

### DIFF
--- a/lib/sacastats/application.ex
+++ b/lib/sacastats/application.ex
@@ -27,17 +27,24 @@ defmodule SacaStats.Application do
       # Start caches
       Supervisor.child_spec(
         {SacaStats.CensusCache,
-         [name: SacaStats.CharacterCache, fallback_fn: &Fallbacks.character/1]},
+         [
+           name: SacaStats.CharacterCache,
+           fallback_fn: &Fallbacks.character/1,
+           entry_expiration_ms: 60 * 60 * 1000
+         ]},
         id: :character_cache
       ),
       Supervisor.child_spec(
         {SacaStats.CensusCache,
-         [name: SacaStats.OnlineStatusCache, fallback_fn: &Fallbacks.online_status/1]},
+         [
+           name: SacaStats.OnlineStatusCache,
+           fallback_fn: &Fallbacks.online_status/1,
+           entry_expiration_ms: 12 * 60 * 60 * 1000
+         ]},
         id: :online_status_cache
       ),
       Supervisor.child_spec(
-        {SacaStats.CensusCache,
-         [name: SacaStats.DiscordClientCache, fallback_fn: fn _ -> :not_found end]},
+        {SacaStats.CensusCache, [name: SacaStats.DiscordClientCache]},
         id: :discord_cache
       ),
       # Start the ESS Websocket

--- a/lib/sacastats/census_cache.ex
+++ b/lib/sacastats/census_cache.ex
@@ -4,6 +4,15 @@ defmodule SacaStats.CensusCache do
   """
   use GenServer
 
+  alias SacaStats.CensusCache
+
+  @check_expired_interval_ms 20 * 1000
+
+  defstruct data: %{},
+            data_expirations: %{},
+            fallback_fn: &CensusCache.default_fallback/1,
+            entry_expiration_ms: :infinity
+
   @type cache_result :: {:ok, value :: any()} | {:error, :not_found}
 
   @type fallback_fn :: (key :: any() -> value :: any() | :not_found)
@@ -11,9 +20,16 @@ defmodule SacaStats.CensusCache do
   ### API
 
   def start_link(opts) when is_list(opts) do
-    {fallback_fn, opts} = Keyword.pop(opts, :fallback_fn, nil)
+    {fallback_fn, opts} = Keyword.pop(opts, :fallback_fn, &default_fallback/1)
+    {entry_expiration, opts} = Keyword.pop(opts, :entry_expiration_ms, :infinity)
 
-    GenServer.start_link(__MODULE__, {nil, fallback_fn}, opts)
+    init_state = %CensusCache{
+      data: %{},
+      fallback_fn: fallback_fn,
+      entry_expiration_ms: entry_expiration
+    }
+
+    GenServer.start_link(__MODULE__, init_state, opts)
   end
 
   @doc """
@@ -40,25 +56,103 @@ defmodule SacaStats.CensusCache do
     GenServer.call(cache, {:get, key})
   end
 
+  @doc """
+  Deletes any entries in the cache under one or more keys. Returns `:ok` even if some (or all) of the keys do not exist
+  in the cache.
+  """
+  @spec delete(cache :: pid() | atom(), key :: any()) :: :ok
+  def delete(cache, key) when not is_list(key) do
+    delete(cache, [key])
+  end
+
+  def delete(cache, keys) do
+    GenServer.cast(cache, {:delete, keys})
+  end
+
+  def default_fallback(_key), do: :not_found
+
   ### Impl
 
-  @impl true
-  def init({_, nil}), do: {:ok, {%{}, fn _ -> :not_found end}}
-  def init({_, fallback_fn}), do: {:ok, {%{}, fallback_fn}}
+  @impl GenServer
+  def init(%CensusCache{} = init_state) do
+    Process.send_after(self(), :remove_expired, @check_expired_interval_ms)
+    {:ok, init_state}
+  end
 
-  @impl true
-  def handle_call({:get, key}, _from, {state, fallback_fn}) do
-    case Map.get_lazy(state, key, fn -> fallback_fn.(key) end) do
+  @impl GenServer
+  def handle_call({:get, key}, _from, %CensusCache{data: data, fallback_fn: fallback_fn} = state) do
+    case Map.get_lazy(data, key, fn -> fallback_fn.(key) end) do
       :not_found ->
-        {:reply, {:error, :not_found}, {state, fallback_fn}}
+        {:reply, {:error, :not_found}, state}
 
       value ->
-        {:reply, {:ok, value}, {Map.put_new(state, key, value), fallback_fn}}
+        state = %CensusCache{
+          state
+          | data: Map.put_new(data, key, value),
+            data_expirations:
+              Map.put_new(
+                state.data_expirations,
+                key,
+                System.os_time(:millisecond) + state.entry_expiration_ms
+              )
+        }
+
+        {:reply, {:ok, value}, state}
     end
   end
 
-  @impl true
-  def handle_cast({:put, keys, value}, {state, fallback_fn}) do
-    {:noreply, {Enum.reduce(keys, state, &Map.put(&2, &1, value)), fallback_fn}}
+  @impl GenServer
+  def handle_cast({:put, keys, value}, %CensusCache{data: data} = state) do
+    state = %CensusCache{
+      state
+      | data: Enum.reduce(keys, data, &Map.put(&2, &1, value)),
+        data_expirations:
+          Enum.reduce(
+            keys,
+            state.data_expirations,
+            &Map.put(&2, &1, System.os_time(:millisecond) + state.entry_expiration_ms)
+          )
+    }
+
+    {:noreply, state}
+  end
+
+  def handle_cast({:delete, keys}, %CensusCache{} = state) do
+    state = do_delete(state, keys)
+
+    {:noreply, state}
+  end
+
+  # message comes from the interval set in init/1
+  @impl GenServer
+  def handle_info(:remove_expired, %CensusCache{} = state) do
+    cache = self()
+
+    Task.start(fn ->
+      keys_to_remove =
+        for {key, expiration} <- state.data_expirations,
+            System.os_time(:millisecond) > expiration do
+          key
+        end
+
+      send(cache, {:remove_expired, keys_to_remove})
+    end)
+
+    Process.send_after(self(), :remove_expired, @check_expired_interval_ms)
+
+    {:noreply, state}
+  end
+
+  @impl GenServer
+  def handle_info({:remove_expired, keys}, %CensusCache{} = state) do
+    {:noreply, do_delete(state, keys)}
+  end
+
+  defp do_delete(%CensusCache{data: data} = state, keys) do
+    %CensusCache{
+      state
+      | data: Map.drop(data, keys),
+        data_expirations: Map.drop(data, keys)
+    }
   end
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,2 +1,2 @@
 ExUnit.start()
-Ecto.Adapters.SQL.Sandbox.mode(SacaStats.Repo, :manual)
+Ecto.Adapters.SQL.Sandbox.mode(SacaStats.Repo, :auto)


### PR DESCRIPTION
`CensusCache`s can now be passed a `entry_expiration_ms` option, which removes entries `entry_expiration_ms` milliseconds after being put in the cache.
Closes #118 