### PR TITLE
Fix being unable to login when the discord user has no avatar

### DIFF
--- a/lib/sacastats/schemas/discord_user.ex
+++ b/lib/sacastats/schemas/discord_user.ex
@@ -28,11 +28,11 @@ defmodule SacaStats.DiscordUser do
   @required_fields [
     :id,
     :username,
-    :discriminator,
-    :avatar
+    :discriminator
   ]
 
   @optional_fields [
+    :avatar,
     :bot,
     :system,
     :mfa_enabled,


### PR DESCRIPTION
When logging in, inserting the Discord user would fail because `:avatar` was a required field.