### PR TITLE
Fix set next aurax visibilities

### DIFF
--- a/lib/sacastats_web/templates/character/weapons.html.heex
+++ b/lib/sacastats_web/templates/character/weapons.html.heex
@@ -553,11 +553,7 @@
 <script type="module">
     //initialize weapon id and kill count map
     import init from "<%= Routes.static_path(@conn, "/js/character/weapons.js") %>";
-    let kills = new Map();
-    $('#weaponTable').bootstrapTable('getData', false).forEach(weapon => {
-        kills.set("weapon" + weapon.id + "Row", weapon.kills)
-    });
-    init(kills);
+    init();
 </script>
 
 <script type="module" src={Routes.static_path(@conn, "/js/character/weapons-table.js")}></script>

--- a/priv/static/js/character/weapons.js
+++ b/priv/static/js/character/weapons.js
@@ -2,8 +2,8 @@ let sortedKills;
 let unsortedKills;
 export let nextAuraxElementID;
 
-function initializeSortedWeaponKillCount(kills) {
-    kills = getTrimmedKillNumbers(kills);
+function initializeSortedWeaponKillCount() {
+    let kills = getTrimmedKillNumbers(unsortedKills);
     sortedKills = new Map([...kills.entries()].sort((a, b) => b[1] - a[1]));
     nextAuraxElementID = [...sortedKills.keys()][0];
 }
@@ -18,7 +18,17 @@ function getTrimmedKillNumbers(kills) {
     return killNumbers;
 }
 
-export default function init(kills) {
-    unsortedKills = kills;
-    initializeSortedWeaponKillCount(kills);
+function getDefaultWeaponStats() {
+    if (document.getElementById("weaponTable") != undefined) {
+        let kills = new Map();
+        $('#weaponTable').bootstrapTable('getData', false).forEach(weapon => {
+            kills.set("weapon" + weapon.id + "Row", weapon.kills)
+        });
+        unsortedKills = kills;
+    }
+}
+
+export default function init() {
+    getDefaultWeaponStats();
+    initializeSortedWeaponKillCount();
 }

--- a/priv/static/js/flex-bootstrap-table-filter.js
+++ b/priv/static/js/flex-bootstrap-table-filter.js
@@ -1,4 +1,4 @@
-import { setMobileHeaderTexts, updateSearchParam, setStickyHeaderWidths } from "/js/flex-bootstrap-table.js";
+import { setMobileHeaderTexts, updateSearchParam, setStickyHeaderWidths, scrollToTopOfTable } from "/js/flex-bootstrap-table.js";
 import { addFormatsToPage, addAnimationToProgressBars } from "/js/formats.js";
 import { showHideNextAuraxButton } from "/js/character/weapons-table.js";
 
@@ -450,7 +450,9 @@ export function updateTableFiltration() {
     //reset pagination clicks
     addPaginationClick();
 }
+
 function tablePaginationClickEventHandler(e) {
+    scrollToTopOfTable(e);
     setNextAuraxVisibilities();
     setTimeout(function () {
         addPaginationClick();

--- a/priv/static/js/flex-bootstrap-table-filter.js
+++ b/priv/static/js/flex-bootstrap-table-filter.js
@@ -446,6 +446,21 @@ export function updateTableFiltration() {
 
     //set table data to filtered data
     $(getTableID()).bootstrapTable('load', sortData(filteredTableData));
+
+    //reset pagination clicks
+    addPaginationClick();
+}
+function tablePaginationClickEventHandler(e) {
+    setNextAuraxVisibilities();
+    setTimeout(function () {
+        addPaginationClick();
+    }, 10);
+}
+function addPaginationClick() {
+    $('a.page-link').off('click', tablePaginationClickEventHandler);
+    $('a.dropdown-item').off('click', tablePaginationClickEventHandler);
+    $('a.page-link').on('click', tablePaginationClickEventHandler);
+    $('a.dropdown-item').on('click', tablePaginationClickEventHandler);
 }
 
 export function sortData(filteredTableData) {

--- a/priv/static/js/flex-bootstrap-table.js
+++ b/priv/static/js/flex-bootstrap-table.js
@@ -249,20 +249,22 @@ export function setupFlexTables() {
     }
 
     function tablePaginationClickEventHandler(e) {
-        if (e.target.classList.contains("page-link") || e.target.classList.contains("page-item")) {
-            $('html, body').animate({
-                scrollTop: $("#" + table.id).offset().top - ((window.innerWidth >= 768) ? 300 : 60) //- 254 to be at top
-            }, 500);
-        }
-        setTimeout(function () {
-            updateTableFormats(table.id);
-        }, 10);
+        /* NOTE: this does not work after a filtration use flex-bootstrap-table-filter's tablePaginationClickEventHandler for anything after a filtration*/
+        scrollToTopOfTable(e);
     }
     function addPaginationClick() {
         $('a.page-link').off('click', tablePaginationClickEventHandler);
         $('a.dropdown-item').off('click', tablePaginationClickEventHandler);
         $('a.page-link').on('click', tablePaginationClickEventHandler);
         $('a.dropdown-item').on('click', tablePaginationClickEventHandler);
+    }
+}
+
+export function scrollToTopOfTable(e) {
+    if (e.target.classList.contains("page-link") || e.target.classList.contains("page-item")) {
+        $('html, body').animate({
+            scrollTop: $("#" + table.id).offset().top - ((window.innerWidth >= 768) ? 300 : 60) //- 254 to be at top
+        }, 500);
     }
 }
 


### PR DESCRIPTION
I actually had to change up the solution for this one. I originally thought that it needed to have the weapon status updated, but those are all of the stats, so pagination doesn't matter. So looking further into it I saw that the pagination on click events were not working after a filtration, which is now fixed.

To recreate show the next aurax weapon and use filtration to make it disappear and reapear. Notice the next aurax button should be working properly even after going back and forth between pages.

This will close #128