### PR TITLE
Fix error when visiting certain new(ish) characters

### DIFF
--- a/lib/sacastats/schemas/census/character.ex
+++ b/lib/sacastats/schemas/census/character.ex
@@ -90,9 +90,9 @@ defmodule SacaStats.Census.Character do
       # flatten profile description
       |> Map.put("profile_type_description", census_res["profile"]["profile_type_description"])
       # flatten/rename character stats objects
-      |> Map.put("stat_history", census_res["stats"]["stat_history"])
-      |> Map.put("stat", census_res["stats"]["stat"])
-      |> Map.put("stat_by_faction", census_res["stats"]["stat_by_faction"])
+      |> Map.put("stat_history", census_res["stats"]["stat_history"] || %{})
+      |> Map.put("stat", census_res["stats"]["stat"] || %{})
+      |> Map.put("stat_by_faction", census_res["stats"]["stat_by_faction"] || %{})
 
     character
     |> cast(params, @fields)


### PR DESCRIPTION
While testing favorite characters, I found that some new(ish) characters with no/missing stats couldn't be viewed when searching for them. Defaulting to an empty map (instead of `nil`) in the stat changeset fnsseems to fix this.