### PR TITLE
Added progress bar headers for BR and Current certs

### DIFF
--- a/lib/sacastats/characters.ex
+++ b/lib/sacastats/characters.ex
@@ -211,13 +211,8 @@ defmodule SacaStats.Characters do
     end
   end
 
-  def get_rank_string(battle_rank, prestige) do
-    if prestige > 0 do
-      "ASP #{prestige} BR #{battle_rank}"
-    else
-      "BR #{battle_rank}"
-    end
-  end
+  def get_rank_string(battle_rank, 0), do: "BR #{battle_rank}"
+  def get_rank_string(battle_rank, prestige), do: "ASP #{prestige} BR #{battle_rank}"
 
   def favorite?(_id, nil), do: false
 

--- a/lib/sacastats_web/templates/character/general.html.heex
+++ b/lib/sacastats_web/templates/character/general.html.heex
@@ -32,6 +32,7 @@
         </div>
         <div class="stat-section">
             <h3 class="text-center">Battle Rank</h3>
+            <h4 class="text-center display-6"><%= @character_info.battle_rank %></h4>
             <div class="progress">
                 <div id="brProgressBar" class="progress-bar progress-bar-striped progress-bar-animated" role="progressbar" aria-valuenow={"#{@character_info.percent_to_next_br}"} aria-valuemin="0" aria-valuemax="100"  style="width: 0;">
                     <%= @character_info.percent_to_next_br %>%
@@ -44,6 +45,7 @@
 
         <div class="stat-section">
             <h3 class="text-center">Current Certification Points</h3>
+            <h4 class="text-center display-6 number"><%= @character_info.available_points %></h4>
             <div class="progress">
                 <div id="certProgressBar" class="progress-bar progress-bar-striped progress-bar-animated bg-warning" role="progressbar" aria-valuenow={"#{SacaStats.Utils.to_percent(@character_info.percent_to_next_point)}"} aria-valuemin="0" aria-valuemax="100" style="width: 0;">
                     <%= SacaStats.Utils.to_percent(@character_info.percent_to_next_point) %>%


### PR DESCRIPTION
I was originally going to add the `BR # ASP #` string (which is why that function was altered, but it just looked strange. I also added a `display-6` on them to make them stand out a bit more against the large progress bar.  Let me know if you have any suggestions on this.

This will close #154.