### PR TITLE
Add a TTL of 24h to entries in character_cache

### DIFF
--- a/lib/sacastats/world_tracker.ex
+++ b/lib/sacastats/world_tracker.ex
@@ -43,7 +43,7 @@ defmodule SacaStats.WorldTracker do
       |> OnlineStatus.changeset(status_params)
       |> Ecto.Changeset.apply_changes()
 
-    Cachex.put(:online_status_cache, status.character_id, status)
+    Cachex.put(:online_status_cache, status.character_id, status, OnlineStatus.put_opts())
 
     state
   end
@@ -56,7 +56,7 @@ defmodule SacaStats.WorldTracker do
       |> OnlineStatus.changeset(status_params)
       |> Ecto.Changeset.apply_changes()
 
-    Cachex.put(:online_status_cache, status.character_id, status)
+    Cachex.put(:online_status_cache, status.character_id, status, OnlineStatus.put_opts())
 
     state
   end


### PR DESCRIPTION
To close #153, this adds a TTL to new entries in our census response caches. I was on the fence regarding TTLs for the online_status_cache, since sessions technically don't have a limit (anyone could stay logged in for days, as long as they're not AFK and get kicked/timed out).

The 12h TTL doesn't prevent our cache from holding an incorrect status for a character, for example when ESS decides not to send us a PlayerLogout event when a character logs out, it'd take many hours for that entry to be wiped, and the app would incorrectly state that the character was still online. To prevent this, we should have our own timeout (15 minutes of no events?) mechanism to help with this issue and help distinguish sessions. I'll create an issue for this I think, but it will probably be something implemented shortly after 1.0.0 (or soon before release if we have time).