### PR TITLE
Fix bug in prod

### DIFF
--- a/lib/sacastats_web/live/character_live/search.ex
+++ b/lib/sacastats_web/live/character_live/search.ex
@@ -52,7 +52,7 @@ defmodule SacaStatsWeb.CharacterLive.Search do
 
     # If the list is empty (i.e. no favorites), return an empty map
     if match?([], favorites_result) do
-      %{}
+      {:ok, %{}}
     else
       favorite_characters = Map.new(favorites_result, &{&1.character_id, &1})
 


### PR DESCRIPTION
This is a quick fix that I put in prod last night - wrapping a returned empty map in an ok tuple to avoid a match error